### PR TITLE
Add low-level graph construction interfaces

### DIFF
--- a/towhee/compiler/graph_builder.py
+++ b/towhee/compiler/graph_builder.py
@@ -15,6 +15,7 @@
 
 from graph_repr import GraphRepr
 from operator_repr import OperatorRepr
+from variable_repr import VariableSet, VariableRepr
 
 
 class GraphBuilder:
@@ -32,51 +33,31 @@ class GraphBuilder:
         self.builder_id = builder_id
         self._pipeline_func = pipeline_func
         self._op_index = 0
-
         self.graph_repr = GraphRepr(builder_id)
+
         # We add a pseudo start operator and a pseudo end operator to the graph.
+        self._start_op = OperatorRepr(GraphBuilder.START_OP)
+        self._end_op = OperatorRepr(GraphBuilder.END_OP)
     
     @property
-    def start_op(self):
-        """
-        The start operator is a pseudo operator. The main functionality of this 
-        operator is to handle the inputs of the pipeline. The start operator has no 
-        inputs, and its outputs are identical to the pipeline's inputs.
-        """
-        if START_OP in self.graph_repr.op:
-            return self.graph_repr.op[START_OP]
-        else:
-            # todo parse pipeline_func's inputs, and construct start operator
-        raise NotImplementedError
+    def pipeline_inputs(self):
+        self._start_op.inputs
 
+    @pipeline_inputs.setter
+    def pipeline_inputs(self, inputs: VariableSet):
+        self._start_op.inputs = inputs
+        self._start_op.outputs = self._start_op.inputs
+     
     @property
-    def end_op(self):
-        """
-        The start operator is a pseudo operator. The main functionality of this 
-        operator is to handle the inputs of the pipeline. The start operator has no 
-        inputs, and its outputs are identical to the pipeline's inputs.
-        """
-        if END_OP in self.graph_repr.op:
-            return self.graph_repr.op[END_OP]
-        else:
-            # todo raise error
-        raise NotImplementedError
+    def pipeline_outputs(self):
+        self._end_op.outputs
 
-    @end_op.setter
-    def end_op(self, pipeline_outputs: VariableSet):
-        """
-        The end operator is a pseudo operator. The main functionality of this 
-        operator is to handle the outputs of the pipeline. The end operator has no 
-        outputs, and its inputs are identical to the pipeline's outputs.
-        """
-        if END_OP in self.graph_repr.op:
-            # todo raise error
-        else:
-            # todo set end operator, and check *pipeline_outputs* against 
-            # pipeline_func's return annotations (if any)
-        raise NotImplementedError
-
-    def add_op(self, op):
+    @pipeline_outputs.setter
+    def pipeline_outputs(self, outputs: VariableSet):
+        self._end_op.inputs = outputs
+        self._end_op.outputs = self._end_op.inputs
+ 
+    def add_op(self, op: Operator) -> OperatorRepr:
         """
         Add an OperatorRepr to the graph
         """
@@ -89,12 +70,37 @@ class GraphBuilder:
         Build the whole graph
         """
         raise NotImplementedError
+   
+    @property
+    def _start_op(self):
+        """
+        The start operator is a pseudo operator. The main functionality of this 
+        operator is to handle the inputs of the pipeline. The start operator has no 
+        inputs, and its outputs are identical to the pipeline's inputs.
+        """
+        return self.graph_repr.op[GraphBuilder.START_OP]
+    
+    @_start_op.setter
+    def _start_op(self, value: OperatorRepr):
+        self.graph_repr.op[GraphBuilder.START_OP] = value
 
-    def _generate_op_name(self, op) -> int:
+    @property
+    def _end_op(self):
         """
-        Generate a unique operator name based on op.name and self._op_index
+        The start operator is a pseudo operator. The main functionality of this 
+        operator is to handle the inputs of the pipeline. The start operator has no 
+        inputs, and its outputs are identical to the pipeline's inputs.
         """
-        raise NotImplementedError
+        return self.graph_repr.op[GraphBuilder.END_OP]
+
+    @_end_op.setter
+    def _end_op(self, value: OperatorRepr):
+        """
+        The end operator is a pseudo operator. The main functionality of this 
+        operator is to handle the outputs of the pipeline. The end operator has no 
+        outputs, and its inputs are identical to the pipeline's outputs.
+        """
+        self.graph_repr.op[GraphBuilder.END_OP] = value
 
 
 def get_graph_builder(key: str = None) -> GraphBuilder:

--- a/towhee/compiler/graph_builder.py
+++ b/towhee/compiler/graph_builder.py
@@ -29,7 +29,7 @@ class GraphBuilder:
     START_OP = '_start'
     END_OP = '_end'
 
-    def __init__(self, builder_id:str, pipeline_func):
+    def __init__(self, builder_id:str = None, pipeline_func = None):
         self.builder_id = builder_id
         self._pipeline_func = pipeline_func
         self._op_index = 0
@@ -57,7 +57,7 @@ class GraphBuilder:
         self._end_op.inputs = outputs
         self._end_op.outputs = self._end_op.inputs
  
-    def add_op(self, op: Operator) -> OperatorRepr:
+    def add_op(self, name: str, op: Operator) -> OperatorRepr:
         """
         Add an OperatorRepr to the graph
         """

--- a/towhee/compiler/operator_repr.py
+++ b/towhee/compiler/operator_repr.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from variable_repr import VariableRepr, VariableSet
+
+
+class OperatorRepr(Operator):
+    """
+    The representation of an operator at compile-phase
+    """
+
+    def __init__(self, unique_op_name: str, op = None):
+        self.op = op
+        self.unique_op_name = unique_op_name
+        self._inputs = None
+        self._outputs = None
+        # todo parse op inputs & outputs
+    
+    @property
+    def inputs(self):
+        return self._inputs
+    
+    @inputs.setter
+    def inputs(self, value):
+        if isinstance(value, list):
+            self._inputs = VariableSet(value)
+        else:
+            self._inputs = value
+ 
+    @property
+    def outputs(self):
+        return self._outputs
+    
+

--- a/towhee/compiler/variable_repr.py
+++ b/towhee/compiler/variable_repr.py
@@ -22,8 +22,8 @@ class VariableRepr:
         self.from_op = from_op
         self.to_op = []
         self.name = name
-        self.type: type
-        self.dtype: type
+        self.type = None
+        self.dtype = None
 
 
 class VariableSet:
@@ -31,13 +31,31 @@ class VariableSet:
     A set of VariableRepr
     """
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str):
         raise NotImplementedError
         return self._var_dict[name]
 
-    def from_dict(self, var_dict: [str, VariableRepr]):
+    def from_dict(self, var_dict: dict):
         """
-        Add variable from dict
+        Add variables from dict
+        """
+        raise NotImplementedError
+    
+    def from_list(self, vars: list):
+        """
+        Add variables from list
+        """
+        raise NotImplementedError
+
+    def from_input_annotations(self, func: function):
+        """
+        Parse variables from a function's input annotations
+        """
+        raise NotImplementedError
+
+    def from_output_annotations(self, func: function):
+        """
+        Parse variables from a function's output annotations
         """
         raise NotImplementedError
 

--- a/towhee/compiler/variable_repr.py
+++ b/towhee/compiler/variable_repr.py
@@ -18,7 +18,7 @@ class VariableRepr:
     The representation of a variable at compile-phase
     """
 
-    def __init__(self, name: str, from_op: str):
+    def __init__(self, name: str, from_op: str = None):
         self.from_op = from_op
         self.to_op = []
         self.name = name
@@ -30,6 +30,11 @@ class VariableSet:
     """
     A set of VariableRepr
     """
+    def __init__(self, value):
+        if isinstance(value, list):
+            self.from_list(value)
+        elif isinstance(value, dict):
+            self._var_dict = value
 
     def __getattr__(self, name: str):
         raise NotImplementedError

--- a/towhee/operator/base_operator.py
+++ b/towhee/operator/base_operator.py
@@ -19,6 +19,19 @@ class Operator:
     """
     The base operator class.
     """
+    
+    def __init__(self):
+        self._params = {}
+        self.name = None
+
+    @property
+    def params(self):
+        return self._params
+    
+    @params.setter
+    def params(self, dict):
+        # todo update parameter dict
+        raise NotImplementedError
 
     @abstractclassmethod
     def op_class(cls):


### PR DESCRIPTION
example of low-level interface:

```
builder = GraphBuilder()

a = VariableRepr('a')
b = VariableRepr('b')
builder.pipeline_inputs = VariableSet([a, b])

add = builder.add_op('add', AddOp)
add.inputs = builder.pipeline_inputs
builder.pipeline_outputs = add.outputs

graph = builder.build()
```


