### PR TITLE
move operator loader to cache

### DIFF
--- a/towhee/cache/operator_loader.py
+++ b/towhee/cache/operator_loader.py
@@ -14,12 +14,10 @@
 
 
 class OperatorLoader:
-    """Load operator from local, hub, http and so on.
     """
-    @staticmethod
-    def load(path):
-        raise NotImplementedError
+    Load operator from hub.
+    """
 
     @staticmethod
-    def _load_local(path):
+    def pull(url:str):
         raise NotImplementedError


### PR DESCRIPTION
In the further design, all the local components will access cache, while the hub-things will be handled by cache.