### PR TITLE
make OperatorPool as a member of TaskExecutor

### DIFF
--- a/towhee/engine/operator_pool.py
+++ b/towhee/engine/operator_pool.py
@@ -13,25 +13,25 @@
 # limitations under the License.
 
 import threading
+from towhee.operator.operator import Operator
 
 
 class OperatorPool:
-    """Entry to create operator
     """
-    _instance = None
-    _lock = threading.Lock()
+    OperatorPool manages Operator creation, acquisition, release, garbage collection.
+    Each TaskExecutor has one OperatorPool.
+    """
 
-    def __new__(cls, *args, **kwargs):
-        if cls._instance is None:
-            with cls._lock:
-                if cls._instance is None:
-                    cls._instance = object.__new__(cls, *args, **kwargs)
-        return cls._instance
-            
-    def acquire(self):
+    def acquire(self, name: str):
+        """
+        Acquire an Operator by name.
+        """
         raise NotImplementedError
 
-    def release(self):
+    def release(self, op: Operator):
+        """
+        Release an Operator.
+        """
         raise NotImplementedError
 
 

--- a/towhee/engine/task_executor.py
+++ b/towhee/engine/task_executor.py
@@ -14,6 +14,7 @@
 
 
 import threading
+from towhee.engine.operator_pool import OperatorPool
 from towhee.operator.operator import Operator
 from towhee.engine.task import Task
 from towhee.engine.task_queue import TaskQueue
@@ -28,24 +29,35 @@ class TaskExecutor(threading.Thread):
         threading.Thread.__init__(self)
         self.name = name
         self._task_queue = TaskQueue()
-        self._ops = []
+        self._op_pool = OperatorPool()
         self._need_stop = False
     
-    def add_op(self, op: Operator):
+    def acquire_op(self, name: str) -> Operator:
         """
-        Add an Operator to the TaskExecutor and load the Operator to device memory.
+        Get an Operator from pool by name
+
+        Args:
+            name: the Operator's unique name in hub
         """
-        self._ops.append(op)
+        raise NotImplementedError
+    
+    def release_op(self, op: Operator):
+        """
+        Release an Operator to pool
+        """
+        raise NotImplementedError
+    
+    def set_op_parallelism(self, name: str, parallel: int = 1):
+        """
+        Set how many Operators with same name can be called concurrently.
+        """
         raise NotImplementedError
     
     def push_task(self, task: Task):
         """
         Push a task to task queue
         """
-        op = self._get_op(task)
-        if op != None:
-            task.op = op
-            self._task_queue.push(task)
+        # todo self._task_queue.push(task)
         raise NotImplementedError
 
     def run(self):

--- a/towhee/engine/task_queue.py
+++ b/towhee/engine/task_queue.py
@@ -19,10 +19,8 @@ from towhee.engine.task import Task
 class TaskQueue:
     """
     The queue where scheduler push tasks and executor pop tasks.
-    Each device has one TaskQueue.
+    Each TaskExecutor has one TaskQueue.
     """
-
-    def __init__(self)
 
     @property
     def empty(self) -> bool:

--- a/towhee/operator/operator.py
+++ b/towhee/operator/operator.py
@@ -23,6 +23,8 @@ class Operator:
     def __init__(self):
         self._params = {}
         self.name = None
+        self.executor = None
+        self.is_stateless = True
 
     @property
     def params(self):


### PR DESCRIPTION
* Operator: 
  * add reference of TaskExecutor
  * add is_stateless tag
* OperatorPool:
  * switch from global singleton to per-TaskExecutor.
* TaskExecutor:
  * add op_acquire method
  * add op_release method
  * add set_op_parallelism method for op concurrent control