### PR TITLE
Adjust pylint config

### DIFF
--- a/pylint.conf
+++ b/pylint.conf
@@ -146,6 +146,7 @@ disable=abstract-method,
         wrong-import-order,
         xrange-builtin,
         zip-builtin-not-iterating,
+        missing-module-docstring,
 
 
 [REPORTS]
@@ -292,7 +293,7 @@ max-module-lines=99999
 # spaces.  Google's externaly-published style guide says 4, consistent with
 # PEP 8.  Here, we use 2 spaces, for conformity with many open-sourced Google
 # projects (like TensorFlow).
-indent-string='  '
+indent-string='    '
 
 # Number of spaces of indent required inside a hanging  or continued line.
 indent-after-paren=4


### PR DESCRIPTION
1. Ignore model docstring
2. indent-string uses 4 spaces