### PR TITLE
Add base representation and update dataframe-related code

### DIFF
--- a/towhee/base_repr.py
+++ b/towhee/base_repr.py
@@ -1,0 +1,52 @@
+# Copyright 2021 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class BaseRepr:
+    """Base representation from which all other representation objects inherit.
+    Primarily implements automatic serialization into YAML/YAML-like string formats,
+    along with defining other universally used properties.
+
+    Args:
+        name:
+            Name of the internal object described by this representation.
+    """
+
+    def __init__(self):
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+
+    def serialize(self) -> str:
+        """Universal function used to serialize this representation.
+
+        Returns:
+            A string containing the serialized version of this representation. Example
+            output:
+
+            'VariableRepr:
+                name: variable
+                vtype: tensor
+                dtype: float'
+        """
+        out = self.__class__.__name___ + '/n'
+        for name in dir(self):
+            value = self.__getattribute__(name)
+            if name[0] != '_' and not isinstance(value, function):
+                if isinstance(value, object):
+                    value = value.__class__.__name__
+                out += name ': ' + str(value) + '/n'
+        return out

--- a/towhee/base_repr.py
+++ b/towhee/base_repr.py
@@ -42,11 +42,11 @@ class BaseRepr:
                 vtype: tensor
                 dtype: float'
         """
-        out = self.__class__.__name___ + '/n'
+        out = self.__class__.__name___ + '\n'
         for name in dir(self):
             value = self.__getattribute__(name)
             if name[0] != '_' and not isinstance(value, function):
                 if isinstance(value, object):
                     value = value.__class__.__name__
-                out += name ': ' + str(value) + '/n'
+                out += name ': ' + str(value) + '\n'
         return out

--- a/towhee/dag/graph_repr.py
+++ b/towhee/dag/graph_repr.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 
-from operator_repr import OperatorRepr
+from towhee.dag.dataframe_repr import DataframeRepr
+from towhee.dag.operator_repr import OperatorRepr
 
 
 class GraphRepr(BaseRepr):
@@ -22,13 +23,18 @@ class GraphRepr(BaseRepr):
     are used during execution to load functions and pass data to the correct operators.
     """
 
-    def __init__(self, builder_id: str):
-        self.builder_id = builder_id
-        self._op_dict = []
-        self._df_dict = []
+    def __init__(self):
+        #TODO(Chiiizzzy)
+        self._ops = {}
+        self._dfs = {}
 
-    def op(self):
-        return self._op_dict
+    @property
+    def ops(self) -> Dict[str, OperatorRepr]:
+        return self._ops
+
+    @property
+    def dfs(self) -> Dict[str, DataframeRepr]:
+        return self._dfs
 
     def from_yaml(self, yaml: str):
         """Import a YAML file describing this graph.
@@ -37,12 +43,14 @@ class GraphRepr(BaseRepr):
             yaml:
                 YAML file (pre-loaded as string) to import.
         """
+        #TODO(Chiiizzzy)
         raise NotImplementedError
 
-    def to_yaml(self):
+    def to_yaml(self) -> str:
         """Export a YAML file describing this graph.
 
         Returns:
             A string with the graph's serialized contents.
         """
+        #TODO(Chiiizzzy)
         raise NotImplementedError

--- a/towhee/dag/graph_repr.py
+++ b/towhee/dag/graph_repr.py
@@ -12,23 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 from operator_repr import OperatorRepr
 
-class GraphRepr:
-    """
-    The representation of a pipeline DAG.
+
+class GraphRepr(BaseRepr):
+    """This class presents a complete representation of a graph and its individual
+    subcomponents, including Operators, Dataframes, and Variables. Graph representations
+    are used during execution to load functions and pass data to the correct operators.
     """
 
     def __init__(self, builder_id: str):
         self.builder_id = builder_id
-        self._op_dict = {}
-        self._var_dict = None
+        self._op_dict = []
+        self._df_dict = []
 
     def op(self):
         return self._op_dict
 
-    def from_yaml(self, yaml):
+    def from_yaml(self, yaml: str):
+        """Import a YAML file describing this graph.
+
+        Args:
+            yaml:
+                YAML file (pre-loaded as string) to import.
+        """
         raise NotImplementedError
 
     def to_yaml(self):
+        """Export a YAML file describing this graph.
+
+        Returns:
+            A string with the graph's serialized contents.
+        """
         raise NotImplementedError

--- a/towhee/dag/operator_repr.py
+++ b/towhee/dag/operator_repr.py
@@ -13,34 +13,45 @@
 # limitations under the License.
 
 
-from variable_repr import VariableRepr, VariableReprSet
+#from towhee.dag.variable_repr import VariableRepr
+#from towhee.dag.variable_repr import VariableReprSet
 
 
-class OperatorRepr(Operator):
+class OperatorRepr(BaseRepr):
+    """This class encapsulates operator representations at compile-time.
+
+    Args:
+        name:
+            Name of the operator represented by this object.
+        df_in:
+            Input dataframes(s) to this object.
+        df_out:
+            This operator's output dataframe.
     """
-    The representation of an operator at compile-phase
-    """
 
-    def __init__(self, unique_op_name: str, op = None):
-        self.op = op
-        self.unique_op_name = unique_op_name
-        self._inputs = None
-        self._outputs = None
-        # todo parse op inputs & outputs
-    
-    @property
-    def inputs(self):
-        return self._inputs
-    
-    @inputs.setter
-    def inputs(self, value):
-        if isinstance(value, list):
-            self._inputs = VariableReprSet(value)
-        else:
-            self._inputs = value
- 
-    @property
-    def outputs(self):
-        return self._outputs
-    
+    def __init__(self, name: str, df_in: DataframeRepr, df_out: DataframeRepr):
+        super().__init__(name)
+        self._df_in = df_in
+        self._df_out = df_out
+        self._iter_in = None
+        self._iter_out = None
 
+    @property
+    def df_in(self):
+        return self._df_in
+
+    @property
+    def df_out(self):
+        return self._df_out
+
+    @df_in.setter
+    def df_in(self, value):
+        if not isinstance(value, DataframeRepr):
+            raise TypeError('The input value for an `Operator` must be an `Dataframe`.')
+        self._df_in = value
+
+    @df_out.setter
+    def df_out(self, value):
+        if not isinstance(value, DataframeRepr):
+            raise TypeError('The output value for an `Operator` must be an `Dataframe`.')
+        self._df_out = value

--- a/towhee/dag/operator_repr.py
+++ b/towhee/dag/operator_repr.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from towhee.dag.dataframe_repr import DataframeRepr
 #from towhee.dag.variable_repr import VariableRepr
 #from towhee.dag.variable_repr import VariableReprSet
 
@@ -45,13 +46,9 @@ class OperatorRepr(BaseRepr):
         return self._df_out
 
     @df_in.setter
-    def df_in(self, value):
-        if not isinstance(value, DataframeRepr):
-            raise TypeError('The input value for an `Operator` must be an `Dataframe`.')
+    def df_in(self, value: DataframeRepr):
         self._df_in = value
 
     @df_out.setter
-    def df_out(self, value):
-        if not isinstance(value, DataframeRepr):
-            raise TypeError('The output value for an `Operator` must be an `Dataframe`.')
+    def df_out(self, value: DataframeRepr):
         self._df_out = value

--- a/towhee/dag/utils.py
+++ b/towhee/dag/utils.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 
+def arg_type_check():
+    #TODO(fzliu): should we use this or a library such as `mypy`?
+    raise NotImplementedError
+
 def pipeline_compiler(target='local'):
     """
     The Pipeline compiler factory

--- a/towhee/dag/variable_repr.py
+++ b/towhee/dag/variable_repr.py
@@ -13,14 +13,34 @@
 # limitations under the License.
 
 
-class VariableRepr:
-    """
-    The representation of a variable at compile-phase
+from towhee.dag.operator_repr import OperatorRepr
+from towhee.base_repr import BaseRepr
+
+
+class VariableRepr(BaseRepr):
+    """The representation of a variable at compile-phase.
+
+    Args:
+        name:
+            Variable name.
+        vtype:
+            This can be one of many possible variable types, such as a numpy array or
+            PyTorch tensor.
+        dtype:
+            A string or instance of `numpy.dtype` indicating the internal data type for
+            this variable.
     """
 
-    def __init__(self, name: str, from_op: str = None):
-        self.from_op = from_op
-        self.to_op = []
-        self.name = name
-        self.type = None
-        self.dtype = None
+    def __init__(self, name: str, vtype: str, dtype: str,
+                 from_op: OperatorRepr = None, to_op: OperatorRepr = None):
+        super().__init__(name)
+        self._vtype = str(vtype)
+        self._dtype = str(dtype)
+
+    @property
+    def vtype(self):
+        return self._vtype
+
+    @property
+    def dtype(self):
+        return self._dtype

--- a/towhee/dataframe/_iterator.py
+++ b/towhee/dataframe/_iterator.py
@@ -16,83 +16,90 @@
 from towhee.dataframe.dataframe import DataFrame
 
 
-class ScalarIterator:
-    """
-    Traverse the variable set with one row per move
+class _BaseIterator:
+    """Base iterator implementation. All iterators should be subclasses of
+    `_BaseIterator`.
+
+    Args:
+        df: The dataframe to iterate over.
     """
 
-    def __init__(self, var_set: VariableSet):
-        """
-        Args:
-            var_set: the variable set to loop through.
-        """
-        self._var_set = var_set
+    def __init__(self, df: DataFrame):
+        self._df = df
 
     def __iter__(self):
-        raise NotImplementedError
+        return self
 
+    def __next__(self):
+        # The base iterator is purposely defined to have exatly 0 elements.
+        raise StopIteration
+
+class MapIterator:
+    """Iterator implementation that traverses the dataframe line-by-line.
+
+    Args:
+        df: The dataframe to iterate over.
+    """
+
+    def __init__(self, df: DataFrame):
+        super().__init__(df)
+
+    def __next__(self):
+        raise NotImplementedError
 
 class BatchIterator:
-    """
-    Traverse the variable set with fixed-size-batch per move
+    """Iterator implementation that traverses the dataframe multiple rows at a time.
+
+    Args:
+        df:
+            The dataframe to iterate over.
+        size:
+            batch size. If size is None, then the whole variable set will be batched
+            together.
     """
 
-    def __init__(self, var_set: VariableSet, size: int = None):
-        """
-        Args:
-            var_set: the variable set to loop through.
-            size: batch size. If size is None, then the whole variable set will be
-                batched together.
-        """
-        self._var_set = var_set
-        self._batch_size = size
+    def __init__(self, df: DataFrame, size: int = None):
+        super().__init__(df)
+        self._size = size
 
-    def __iter__(self):
-        """
-        Examples:
-        """
+    def __next__(self):
         raise NotImplementedError
 
-
 class GroupIterator:
-    """
-    Traverse the variable set based on a custom group-by function
+    """Iterator implementation that traverses the dataframe based on a custom group-by
+    function.
+
+    Args:
+        df:
+            The dataframe to iterate over.
+        func:
+            The function used to return grouped data within the dataframe.
     """
 
-    def __init__(self, var_set: VariableSet, group_by_func: function):
-        """
-        Args:
-            var_set: the variable set to loop through.
-            group_by_func: the group by function.
-        """
-        self._var_set = var_set
-        self._group_by_func = group_by_func
+    def __init__(self, df: DataFrame, func: function):
+        super().__init__(df)
+        self._func = func
 
-    def __iter__(self):
-        """
-        Examples:
-        """
+    def __next__(self):
         raise NotImplementedError
 
 
 class RepeatIterator:
-    """
-    In the case that a variable set has only one row, *RepeatIterator* will repeatly
-    access this row.
-    """
+    """Iterator implementation that repeatedly accesses the first line of the dataframe.
 
-    def __init__(self, var_set: VariableSet, n: int = None):
-        """
         Args:
-            var_set: the variable set to loop through.
-            n: the repeat times. If not set, the iterator will never ends.
-        """
-        self._var_set = var_set
+            df:
+                The dataframe to iterate over.
+            n:
+                the repeat times. If `None`, the iterator will loop continuously.
+    """
+
+    def __init__(self, df: DataFrame, n: int = None):
+        super.__init__(df)
         self._n = n
+        self._i = 0
 
-    def __iter__(self):
-        """
-        Examples:
-        """
-        raise NotImplementedError
-
+    def __next__(self):
+        if self._i >= self._n:
+            raise StopIteration
+        return self._data[0]

--- a/towhee/dataframe/dataframe.py
+++ b/towhee/dataframe/dataframe.py
@@ -13,40 +13,56 @@
 # limitations under the License.
 
 
-from towhee.dataframe._iterator import ScalarIterator, GroupIterator, BatchIterator, RepeatIterator
+from towhee.dataframe._iterator import ScalarIterator
+from towhee.dataframe._iterator import GroupIterator
+from towhee.dataframe._iterator import BatchIterator
+from towhee.dataframe._iterator import RepeatIterator
 
 
 class DataFrame:
-    """
-    A collection of immutable, potentially heterogeneous arrays of data.
+    """A dataframe is a collection of immutable, potentially heterogeneous blogs of
+    data.
     """
 
-    def __init__(self, name: str = None, data = None):
-        """
+    def __init__(self, name: str, data: list[tuple[Variable]] = None):
+        """DataFrame constructor.
+
         Args:
-            name: the name of the DataFrame
-            data: a list of Array with same size
+            name:
+                Name of the dataframe; `DataFrame` names should be the same as its
+                representation.
+            data:
+                A list of data tuples - in all instances, the number of elements per
+                tuple should be identical throughout the entire lifetime of the
+                `Dataframe`. These tuples can be interpreted as being direct outputs
+                into downstream operators.
         """
-        self.name = name
-        self.columns = data
-
-
-class DFIterator:
-    """
-    The DataFrame iterator
-    """
-    def __init__(self, df: DataFrame):
         self._iter = ScalarIterator(df)
-        self._df = df
+        self._name = name
+        self._data = data
 
-    def __iter__(self):
-        return iter(self._iter)
-    
-    def group_by(self, func):
-        self._iter = GroupIterator(self._df, func)
-    
-    def batch(self, size = None):
-        self._iter = BatchIterator(self._df, size)
+    @property
+    def name(self):
+        return self._name
 
-    def repeat(self, n = None):
-        self._iter = RepeatIterator(self._df, n)
+    def __getitem__(self, val):
+        return data[val]
+
+    def __delete__(self, val):
+        del data[val]
+
+    def append(self, item: tuple[Variable]):
+        data.append(item)
+
+    def iter_scalar(self):
+        #TODO(fzliu): register iterator
+        return iter(ScalarIterator(self._df))
+
+    def iter_group_by(self, func: function):
+        return iter(GroupIterator(self._df, func))
+
+    def iter_batch(self, size: int):
+        return iter(BatchIterator(self._df, size))
+
+    def iter_repeat(self, n: int):
+        return iter(RepeatIterator(self._df, n))

--- a/towhee/engine/variable.py
+++ b/towhee/engine/variable.py
@@ -13,24 +13,25 @@
 # limitations under the License.
 
 
-from towhee.dataframe.dataframe import DFIterator, DataFrame
+from towhee.dataframe.dataframe import DataFrame
 from towhee.engine.operator_context import OperatorContext
 
 
 class Variable:
-    """
-    A Variable can be part of an Operator's inputs or outputs.
+    """A `Variable` is a blob of data which can be one of many data types such as:
+    `bool` (scalar), `int` (scalar), `float` (scalar), `tuple` (array), `list` (array),
+    `np.ndarray` (array), `string` (misc).
+
+    Args:
+        name:
+            Variable name; should be identical to its representation counterpart.
+        df:
+            The DataFrame this Variable belongs to.
+        op_ctx:
+            The OperatorContext this Variable belongs to.
     """
 
-    def __init__(self, name: str, df: DataFrame, iter: DFIterator, op_ctx: OperatorContext):
-        """
-        Args:
-            name: the Variable's name
-            df: the DataFrame this Variable belongs to
-            iter: the DataFrame's iterator
-            op_ctx: the OperatorContext this Variable belongs to.
-        """
-        self.name = name
-        self.df = df
-        self.iter = iter
-        self.op_ctx = op_ctx
+    def __init__(self, name: str, df: DataFrame, op_ctx: OperatorContext):
+        self._name = name
+        self._df = df
+        self._op_ctx = op_ctx


### PR DESCRIPTION
(Re-opening after rebase)
- Add a `BaseRepr` object from which all representation classes inherit
- Completed `DataframeRepr` based on example YAML, updated annotation-based initialization functions
- Updated dataframe-related code (still a WIP, needs further edits based on internal discussions)
- Updated docstrings and docstring formats for several DAG-related files
- Removed `DFIterator`, iterators can now be called directly from `Dataframe` objects
- Other slight formatting modifications