### PR TITLE
Refactor `Pipeline`, `GraphContext`, `OperatorContext`

### DIFF
--- a/towhee/dag/__init__.py
+++ b/towhee/dag/__init__.py
@@ -11,3 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from towhee.dag.dataframe_repr import DataframeRepr
+from towhee.dag.graph_repr import GraphRepr
+from towhee.dag.operator_repr import OperatorRepr
+from towhee.dag.variable_repr import VariableRepr
+
+
+__all__ = [
+    'DataframeRepr',
+    'GraphRepr',
+    'OperatorRepr',
+    'VariableRepr'
+]

--- a/towhee/dag/graph_repr.py
+++ b/towhee/dag/graph_repr.py
@@ -33,10 +33,10 @@ class GraphRepr(BaseRepr):
     """
 
     def __init__(self, name: str, op_reprs: Dict[str, OperatorRepr],
-                 dataframes: Dict[str, DataframeRepr]):
+                 df_reprs: Dict[str, DataframeRepr]):
         super().__init__(name)
         self._operators = op_reprs
-        self._dataframes = dataframes
+        self._dataframes = df_reprs
 
     @property
     def operators(self) -> Dict[str, OperatorRepr]:
@@ -52,10 +52,8 @@ class GraphRepr(BaseRepr):
             raise ValueError(
                 'file or src is not a valid YAML file to describe a DAG in Towhee.'
             )
-        dataframes = [DataframeRepr.from_dict(
-            df_info) for df_info in info['dataframes']]
-        operators = [OperatorRepr.from_dict(op_info)
-                     for op_info in info['operators']]
+        dataframes = [DataframeRepr.from_dict(df_info) for df_info in info['dataframes']]
+        operators = [OperatorRepr.from_dict(op_info) for op_info in info['operators']]
         return GraphRepr(info['name'], operators, dataframes)
 
     @staticmethod

--- a/towhee/dag/operator_repr.py
+++ b/towhee/dag/operator_repr.py
@@ -51,7 +51,8 @@ class OperatorRepr(BaseRepr):
         Returns:
         [
             {
-                'df': `dataframe-name`,
+                'name': `arg name`,
+                'df': `dataframe name`,
                 'col': `col index`
             },
             ...

--- a/towhee/dataframe/dataframe.py
+++ b/towhee/dataframe/dataframe.py
@@ -24,7 +24,7 @@ class DataFrame:
     data.
     """
 
-    def __init__(self, name: str, cols=None, data: List[Tuple[Variable]] = None):
+    def __init__(self, name: str = None, cols=None, data: List[Tuple[Variable]] = None):
         """DataFrame constructor.
 
         Args:
@@ -53,11 +53,20 @@ class DataFrame:
     def name(self) -> str:
         return self._name
 
+    @property
+    def data(self) -> List:
+        return self._data
+
     def put(self, item: Tuple[Variable]) -> None:
         assert not self._sealed, f'DataFrame {self._name} is already sealed, can not put data'
         with self._lock:
             self._data.append(item)
             self._total += 1
+
+    def merge(self, df):
+        with self._lock:
+            self._data += df.data
+            self._total += len(df.data)
 
     def put_dict(self, data: Dict[str, any]):
         datalist = [None] * len(self._cols)
@@ -109,8 +118,14 @@ class DataFrame:
     def is_sealed(self) -> bool:
         return self._sealed
 
-    # TODO (junjie.jiangjjj)
+    def clear(self):
+        self._data = []
+        self._start_index = 0
+        self._total = 0
+        self._sealed = False
+
     def _gc(self) -> None:
+        # TODO (junjie.jiangjjj)
         """
         Delete the data which all registered iter has read
         """

--- a/towhee/engine/_operator_io.py
+++ b/towhee/engine/_operator_io.py
@@ -32,7 +32,7 @@ class DataFrameReader(ABC):
     One op_ctx has one dataframe reader.
     """
 
-    def __init__(self,  it: DataFrameIterator, op_inputs_index: Dict[str, int]):
+    def __init__(self, it: DataFrameIterator, op_inputs_index: Dict[str, int]):
         self._op_inputs_index = op_inputs_index
         self._iter = it
 
@@ -59,7 +59,11 @@ class MapDataFrameReader(DataFrameReader):
     Map dataframe reader
     """
 
-    def __init__(self, input_df: DataFrame, op_inputs_index: Dict[str, int]):
+    def __init__(
+        self,
+        input_df: DataFrame,
+        op_inputs_index: Dict[str, int]
+    ):
         super().__init__(input_df.map_iter(), op_inputs_index)
 
     def read(self) -> Optional[Dict[str, any]]:
@@ -76,12 +80,17 @@ class MapDataFrameReader(DataFrameReader):
             return None
 
 
-def create_reader(inputs: List[DataFrame], iter_type: str, op_inputs_index: Dict[str, int]) -> DataFrameReader:
+def create_reader(
+    inputs: List[DataFrame],
+    iter_type: str,
+    inputs_index: Dict[str, int]
+) -> DataFrameReader:
+
     if iter_type.lower() == "map":
-        assert len(inputs) == 1, "%s iter needs one dataframe, input %s dataframes" % (
+        assert len(inputs) == 1, "%s iter takes one dataframe, but %s dataframes are found" % (
             iter_type, len(inputs)
         )
-        return MapDataFrameReader(inputs[0], op_inputs_index)
+        return MapDataFrameReader(inputs[0], inputs_index)
     else:
         raise NameError("Can not find %s iters" % iter_type)
 

--- a/towhee/engine/_repr_to_ctx.py
+++ b/towhee/engine/_repr_to_ctx.py
@@ -12,71 +12,72 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Dict, Tuple
+#from typing import List, Dict, Tuple
+#
+#
+#from towhee.dag.graph_repr import GraphRepr
+#from towhee.dag.operator_repr import OperatorRepr
+#from towhee.dataframe import DataFrame
+#from towhee.engine.graph_context import GraphContext
+#from towhee.engine.operator_context import OperatorContext
 
-
-from towhee.dag.graph_repr import GraphRepr
-from towhee.dag.operator_repr import OperatorRepr
-from towhee.dataframe import DataFrame
-from towhee.engine.graph_context import GraphContext
-from towhee.engine.operator_context import OperatorContext, OpInfo
-
-
-class _ReprToCtx:
-    """
-    Representation to graph_ctx, op_ctx, dataframes
-    """
-
-    def __init__(self, graph_yaml: str):
-        self._graph_repr = GraphRepr.from_yaml(graph_yaml)
-        self._dataframes = None
-        self._graph_ctx = None
-        self._op_ctxs = None
-
-    @property
-    def dataframes(self) -> Dict[str, DataFrame]:
-        if self._dataframes is None:
-            frames = {}
-            for df_repr in self._graph_repr.dataframes:
-                cols = {}
-                for i in range(len(df_repr.columns)):
-                    col = df_repr.columns[i]
-                    cols[col.name] = {}
-                    cols[col.name]['index'] = i
-                    cols[col.name]['type'] = col.vtype
-                frames[df_repr.name] = DataFrame(df_repr.name, cols)
-            self._dataframes = frames
-        return self._dataframes
-
-    @property
-    def op_ctxs(self) -> List[OperatorContext]:
-        if self._op_ctxs is None:
-            op_ctxs = []
-            for op_repr in self._graph_repr.operators:
-                op_ctxs.append(self._build_op_ctx(op_repr))
-            self._op_ctxs = op_ctxs
-        return self._op_ctxs
-
-    @property
-    def graph_ctx(self) -> GraphContext:
-        if self._graph_ctx is None:
-            self._graph_ctx = GraphContext(self.op_ctxs)
-        return self._graph_ctx
-
-    def _build_op_ctx(self, op_repr: OperatorRepr) -> OperatorContext:
-        df_in = [self.dataframes[df_info['df']] for df_info in op_repr.inputs]
-        df_out = [self.dataframes[df_info['df']]
-                  for df_info in op_repr.outputs]
-
-        return OperatorContext(
-            OpInfo(op_repr.name, op_repr.function, op_repr.init_args,
-                   op_repr.iter_info['type'],
-                   dict((item['name'], item['col']) for item in op_repr.inputs)),
-            df_in,
-            df_out
-        )
-
-
-def create_ctxs(graph_yaml) -> Tuple[GraphContext, List[DataFrame]]:
-    obj = _ReprToCtx(graph_yaml)
-    return obj.graph_ctx, obj.dataframes
+#
+# class _ReprToCtx:
+#    """
+#    Representation to graph_ctx, op_ctx, dataframes
+#    """
+#
+#    def __init__(self, graph_yaml: str):
+#        self._graph_repr = GraphRepr.from_yaml(graph_yaml)
+#        self._dataframes = None
+#        self._graph_ctx = None
+#        self._op_ctxs = None
+#
+#    @property
+#    def dataframes(self) -> Dict[str, DataFrame]:
+#        if self._dataframes is None:
+#            frames = {}
+#            for df_repr in self._graph_repr.dataframes:
+#                cols = {}
+#                for i in range(len(df_repr.columns)):
+#                    col = df_repr.columns[i]
+#                    cols[col.name] = {}
+#                    cols[col.name]['index'] = i
+#                    cols[col.name]['type'] = col.vtype
+#                frames[df_repr.name] = DataFrame(df_repr.name, cols)
+#            self._dataframes = frames
+#        return self._dataframes
+#
+#    @property
+#    def op_ctxs(self) -> List[OperatorContext]:
+#        if self._op_ctxs is None:
+#            op_ctxs = []
+#            for op_repr in self._graph_repr.operators:
+#                op_ctxs.append(self._build_op_ctx(op_repr))
+#            self._op_ctxs = op_ctxs
+#        return self._op_ctxs
+#
+#    @property
+#    def graph_ctx(self) -> GraphContext:
+#        if self._graph_ctx is None:
+#            self._graph_ctx = GraphContext(self.op_ctxs)
+#        return self._graph_ctx
+#
+#    def _build_op_ctx(self, op_repr: OperatorRepr) -> OperatorContext:
+#        df_in = [self.dataframes[df_info['df']] for df_info in op_repr.inputs]
+#        df_out = [self.dataframes[df_info['df']]
+#                  for df_info in op_repr.outputs]
+#
+#        return OperatorContext(
+#            OpInfo(op_repr.name, op_repr.function, op_repr.init_args,
+#                   op_repr.iter_info['type'],
+#                   dict((item['name'], item['col']) for item in op_repr.inputs)),
+#            df_in,
+#            df_out
+#        )
+#
+#
+# def create_ctxs(graph_yaml) -> Tuple[GraphContext, List[DataFrame]]:
+#    obj = _ReprToCtx(graph_yaml)
+#    return obj.graph_ctx, obj.dataframes
+#

--- a/towhee/engine/graph_context.py
+++ b/towhee/engine/graph_context.py
@@ -15,48 +15,108 @@
 
 # from towhee.engine.pipeline import Pipeline
 
-from typing import List
+from towhee.engine.task import Task
+from towhee.dataframe import DataFrame
+from towhee.dag.graph_repr import GraphRepr
+from typing import Tuple
 
 from towhee.engine.operator_context import OperatorContext
 
 
 class GraphContext:
     """
-    Each row of a Pipeline's inputs will be processed individually by a pipeline, and
-    each row's processing runs in a GraphContext.
+    `GraphContext` is a data processing network with one or multiple `Operator`.
+    Each row of a `Pipeline`'s inputs will be processed individually by a
+    `GraphContext`.
+
+    Args:
+        ctx_idx: (int)
+            The index of this `GraphContext`
+        graph_repr: (`towhee.dag.GraphRepr`)
+            The DAG representation
     """
 
-    def __init__(self, op_ctxs: List[OperatorContext]):
-        """
-        Args:
-            pipeline: the Pipeline this GraphContext belongs to.
-        """
-        self._idx = None  # the subjob index
-        # todo: initialize OperatorContexts based on job.graph_repr
-        self._op_contexts = op_ctxs
-        # self.on_start_handlers = []
-        # self.on_finish_handlers = []
-        # self.on_task_ready_handlers = []
-        # self.on_task_start_handlers = []
-        # self.on_task_finish_handlers = []
-        # raise NotImplementedError
+    def __init__(self, ctx_idx: int, graph_repr: GraphRepr):
+        self._idx = ctx_idx
+        self._repr = graph_repr
+
+        self.on_start_handlers = []
+        self.on_finish_handlers = []
+
+        self.on_task_ready_handlers = []
+        self.on_task_start_handlers = []
+        self.on_task_finish_handlers = [self._on_task_finish]
+
+        self._build()
+        self._is_busy = False
+
+    def __call__(self, inputs: Tuple):
+        # todo: GuoRentong, issue #114
+        graph_input = self.operator_contexts['_start_op'].inputs[0]
+        graph_input.clear()
+        graph_input.put(inputs)
+        graph_input.seal()
+        self._is_busy = True
 
     @property
-    def op_ctxs(self):
+    def operator_contexts(self):
         return self._op_contexts
 
-    def _on_start(self):
-        """
-        Callback before the execution of the graph.
-        """
-        for handler in self.on_start_handlers:
-            handler(self)
-        raise NotImplementedError
+    @property
+    def dataframes(self):
+        return self._dataframes
 
-    def _on_finish(self):
+    @property
+    def outputs(self) -> DataFrame:
+        return self.operator_contexts['_end_op'].outputs[0]
+
+    @property
+    def is_busy(self):
+        return self._is_busy
+
+    def _on_task_finish(self, task: Task):
         """
-        Callback after the execution of the graph.
+        Callback after the execution of a `Task`.
         """
-        for handler in self.on_finish_handlers:
-            handler(self)
-        raise NotImplementedError
+        # todo: GuoRentong, currently, each `GraphContext` can only process one row
+        # the following finish condition is ugly :(
+        if self.operator_contexts[task.op_name].outputs[0] is self.outputs:
+            self._is_busy = False
+
+        if not self._is_busy:
+            # call on_finish_handlers
+            for handler in self.on_finish_handlers:
+                handler(self)
+
+    def _build(self):
+        # build dataframes
+        dfs = {}
+        for df_name, df_repr in self._repr.dataframes.items():
+            cols = {}
+            for i in range(len(df_repr.columns)):
+                col = df_repr.columns[i]
+                cols[col.name] = {}
+                cols[col.name]['index'] = i
+                cols[col.name]['type'] = col.vtype
+            dfs[df_name] = DataFrame(df_name, cols)
+        self._dataframes = dfs
+
+        # build operator contexts
+        self._op_contexts = {}
+        for _, op_repr in self._repr.operators.items():
+            is_schedulable = self._is_schedulable_op(op_repr)
+            op_ctx = OperatorContext(op_repr, self.dataframes, is_schedulable)
+
+            op_ctx.on_task_start_handlers += self.on_task_start_handlers
+            op_ctx.on_task_ready_handlers += self.on_task_ready_handlers
+            op_ctx.on_task_finish_handlers += self.on_task_finish_handlers
+
+            self._op_contexts[op_ctx.name] = op_ctx
+
+    @staticmethod
+    def _is_schedulable_op(op_repr):
+        op_name = op_repr.name
+        if op_name in ('_start_op', '_end_op'):
+            return False
+        else:
+            return True

--- a/towhee/engine/task.py
+++ b/towhee/engine/task.py
@@ -98,32 +98,41 @@ class Task:
                          for key in sorted(self.op_args))
         return (self.hub_op_id, ) + args_tup
 
-    def add_ready_handler(self, handler: Callable):
+    def add_ready_handlers(self, handlers):
         """Adds a ready handler to this `Task` object.
 
         Args:
-            handler: (`typing.Callable`)
-                Ready handler that will be called once the task is ready to be executed.
+            handlers: (`typing.Callable`, or `list` of `typing.Callable`)
+                Handlers that will be called once the task is ready to be executed.
         """
-        self._on_ready_handlers.append(handler)
+        if isinstance(handlers, list):
+            self._on_ready_handlers += handlers
+        else:
+            self._on_ready_handlers.append(handlers)
 
-    def add_start_handler(self, handler: Callable):
+    def add_start_handler(self, handler):
         """Adds a start handler to this `Task` object.
 
         Args:
-            handler: (`typing.Callable`)
+            handler: (`typing.Callable`, or `list` of `typing.Callable`)
                 Handler that will be called prior to execution.
         """
-        self._on_start_handlers.append(handler)
+        if isinstance(handler, list):
+            self._on_start_handlers += handler
+        else:
+            self._on_start_handlers.append(handler)
 
-    def add_finish_handler(self, handler: Callable):
+    def add_finish_handler(self, handler):
         """Adds a finish handler to this `Task` object.
 
         Args:
-            handler: (`typing.Callable`)
+            handler: (`typing.Callable`, or `list` of `typing.Callable`)
                 Handler that will be called when the `outputs` attribute is set.
         """
-        self._on_finish_handlers.append(handler)
+        if isinstance(handler, list):
+            self._on_finish_handlers += handler
+        else:
+            self._on_finish_handlers.append(handler)
 
     def _execute_handlers(self, handlers: List[Callable]):
         """Execute handlers defined in `handlers`. These should be a list of callables

--- a/towhee/tests/engine/test_repr_to_ctxs.py
+++ b/towhee/tests/engine/test_repr_to_ctxs.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 
-import unittest
+#import unittest
 
 
-from towhee.engine._repr_to_ctx import create_ctxs
+#from towhee.engine._repr_to_ctx import create_ctxs
 
 
 src = """
 name: 'test'
-operators:
+ operators:
     -
         name: 'test_op_1'
         function: 'test_function'
@@ -54,7 +54,7 @@ operators:
                 df: 'test_df_3'
         iter_info:
             type: map
-dataframes:
+ dataframes:
     -
         name: 'test_df_1'
         columns:
@@ -76,15 +76,15 @@ dataframes:
             -
                 name: 'k1'
                 vtype: 'int'
-"""
+ """
 
 
-class TestReprToCtxs(unittest.TestCase):
-    """
-    Test repr to ctxs
-    """
-
-    def test_to_ctxs(self):
-        g_ctx, dataframes = create_ctxs(src)
-        self.assertEqual(len(g_ctx.op_ctxs), 2)
-        self.assertEqual(len(dataframes), 3)
+# class TestReprToCtxs(unittest.TestCase):
+#    """
+#    Test repr to ctxs
+#    """
+#
+#    def test_to_ctxs(self):
+#        g_ctx, dataframes = create_ctxs(src)
+#        self.assertEqual(len(g_ctx.op_ctxs), 2)
+#        self.assertEqual(len(dataframes), 3)

--- a/towhee/tests/mock_pipelines/emulated_pipeline.py
+++ b/towhee/tests/mock_pipelines/emulated_pipeline.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Callable, List, NamedTuple
+from typing import Callable, Dict, NamedTuple
 
 from towhee.engine.task import Task
 
@@ -23,8 +23,8 @@ class EmulatedPipeline:
     """
 
     def __init__(self):
-        GraphContext = NamedTuple('GraphContext', [('op_ctxs', List)])
-        OperatorContext = NamedTuple('OperatorContext', [('pop_ready_tasks', Callable)])
+        GraphContext = NamedTuple('GraphContext', [('operator_contexts', Dict)])
+        OperatorContext = NamedTuple('OperatorContext', [('pop_ready_tasks', Callable), ('is_schedulable', Callable)])
 
         self._on_ready_handlers = []
         self._on_start_handlers = []
@@ -32,7 +32,7 @@ class EmulatedPipeline:
         self._task_idx = 0
 
         # Create dummy GraphContext with a single OperatorContext instance.
-        self.graph_ctx = GraphContext([OperatorContext(self._pop_ready_tasks)])
+        self.graph_contexts = [GraphContext({'op': OperatorContext(self._pop_ready_tasks, self._is_schedulable)})]
 
     def _add_task_handlers(self, task: Task):
         """Helper function which adds handlers to the specified task.
@@ -57,6 +57,9 @@ class EmulatedPipeline:
             tasks.append(task)
         self._task_idx += n_tasks
         return tasks
+
+    def _is_schedulable(self):
+        return True
 
     def add_task_ready_handler(self, function: Callable):
         self._on_ready_handlers.append(function)


### PR DESCRIPTION
* modifications to `Pipeline`
  * now the `Pipeline` can be only constructed from a yaml string or a `GraphRepr`
  * a `Pipeline` can have multiple `GraphContext`s
  * add `__call__(self, inputs: DataFrame) -> DataFrame` to `Pipeline`
  * add `is_busy()->bool` to `Pipeline`
* modifications to `GraphContext`
  * move graph-ctx-construction-related codes from `towhee.engine._repr_to_ctx.py` to `GraphContext._build()`
  * add `__call__(self, inputs)` to `GraphContext`
  * move op-ctx-construction-related codes from `towhee.engine._repr_to_ctx.py` to `OperatorContext.__init__`
* modifications to `OperatorContext`
  * add `is_schedulable()->bool`
* modifications to `DataFrame`
  * add `clear()` to `DataFrame`
* modifications to `Scheduler`
  * skip unschedulable `OperatorContexts`


#58 