### PR TITLE
Allow Towhee to run natively on Ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Towhee is a flexible machine learning framework currently focused on computing d
 Towhee can be installed as follows:
 
 ```bash
+% pip install -U pip
+% pip cache purge
 % pip install towhee
 ```
 
@@ -39,7 +41,7 @@ Towhee provides pre-built computer vision models which can be used to generate e
 >>> from PIL import Image
 
 # Use our in-built embedding pipeline
->>> img = Image.open('towhee_logo.png')
+>>> img = Image.open('towhee_logo.png').convert('RGB')
 >>> embedding_pipeline = pipeline('embedding-pipeline')
 >>> embedding = embedding_pipeline(img)
 ```
@@ -70,4 +72,4 @@ Custom machine learning pipelines can be defined in a YAML file and uploaded to 
 
 - __Extensible__: Individual operators within each pipeline can be reconfigured and reused in different pipelines. A pipeline can be deployed anywhere you want - on your local machine, on a server with 4 GPUs, or in the cloud (coming soon&trade;)
 
-- __Convinient__: Operators can be defined as a single function; new pipelines can be constructed by looking at input and output annotations for those functions. Towhee provides a high-level interface for creating new graphs by stringing together functions in Python code.
+- __Convenient__: Operators can be defined as a single function; new pipelines can be constructed by looking at input and output annotations for those functions. Towhee provides a high-level interface for creating new graphs by stringing together functions in Python code.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ class PostInstallCommand(install):
 
 setup(
     name="towhee",
-    version="0.1.1",
+    version="0.1.2",
     description="",
     author="Towhee Team",
     author_email="towhee-team@zilliz.com",
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         'torch>=1.2.0',
         'torchvision>=0.4.0',
-        'numpy>=1.20.3',
+        'numpy>=1.19.5',
         'pandas>=1.2.4',
         'pyyaml>=5.3',
         'requests>=2.25',


### PR DESCRIPTION
See issue #153.
- Lowered numpy version requirement
- Updated README with commands needed to run v0.1
- Bumped Towhee release version