### PR TITLE
Earlier operator cache check and empty input check

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Towhee provides pre-built computer vision models which can be used to generate e
 >>> from PIL import Image
 
 # Use our in-built embedding pipeline
->>> img = Image.open('towhee_logo.png').convert('RGB')
+>>> img = Image.open('towhee_logo.png')
 >>> embedding_pipeline = pipeline('image-embedding')
 >>> embedding = embedding_pipeline(img)
 ```
@@ -51,8 +51,8 @@ Your image embedding is now stored in `embedding`. It's that simple.
 Custom machine learning pipelines can be defined in a YAML file and uploaded to the Towhee hub (coming soon&trade;). Pipelines which already exist in the local Towhee cache (`/$HOME/.towhee/pipelines`) will be automatically loaded:
 
 ```python
-# This will load the pipeline defined at $HOME/.towhee/pipelines/fzliu/resnet50-embedding.yaml
->>> embedding_pipeline = pipeline('fzliu/resnet50-embedding')
+# This will load the pipeline defined at $HOME/.towhee/pipelines/fzliu/resnet50_embedding.yaml
+>>> embedding_pipeline = pipeline('fzliu/resnet50_embedding')
 >>> embedding = embedding_pipeline(img)
 ```
 

--- a/towhee/__init__.py
+++ b/towhee/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from pathlib import Path
 from typing import Any, Tuple
 import os
@@ -52,6 +51,10 @@ class _PipelineWrapper:
     def __call__(self, *args) -> Tuple[Any]:
         """Wraps the input arguments around a `Dataframe` for Pipeline.__call__().
         """
+        # Check if no data supplied to pipeline
+        if not args:
+            raise ValueError(
+                'No data supplied to pipeline')
 
         # Create `Variable` tuple from input arguments.
         vargs = []
@@ -110,7 +113,7 @@ def pipeline(task: str, cache: str = None):
     yaml_path = cache_path / (task + '.yaml')
 
     if not yaml_path.is_file():
-        raise NameError('Can not find pipeline by name %s ' % task)
+        raise NameError(F'Can not find pipeline by name {task}')
 
     # Create `Pipeline` object given its graph representation, then add the pipeline to
     # the existing `Engine`.

--- a/towhee/engine/graph_context.py
+++ b/towhee/engine/graph_context.py
@@ -122,9 +122,9 @@ class GraphContext:
             is_schedulable = self._is_schedulable_op(op_repr)
             op_ctx = OperatorContext(op_repr, self.dataframes, is_schedulable)
 
-            op_ctx.on_task_start_handlers += self.on_task_start_handlers
-            op_ctx.on_task_ready_handlers += self.on_task_ready_handlers
-            op_ctx.on_task_finish_handlers += self.on_task_finish_handlers
+            op_ctx.add_task_start_handler(self.on_task_start_handlers)
+            op_ctx.add_task_ready_handler(self.on_task_ready_handlers)
+            op_ctx.add_task_finish_handler(self.on_task_finish_handlers)
 
             self._op_contexts[op_ctx.name] = op_ctx
 

--- a/towhee/engine/pipeline.py
+++ b/towhee/engine/pipeline.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from towhee.dag.graph_repr import GraphRepr
-
 from towhee.engine.graph_context import GraphContext
 from towhee.dataframe import DataFrame
+from towhee.engine import LOCAL_OPERATOR_CACHE
 
 
 class Pipeline:
@@ -40,6 +40,8 @@ class Pipeline:
         self.on_graph_finish_handlers = []
         self._scheduler = None
 
+        # self.fill_cache()
+
         # self._cv = threading.Condition()
         # self.on_graph_finish_handlers = [self._on_graph_finish]
         # self._build()
@@ -53,7 +55,7 @@ class Pipeline:
         """
         if self._scheduler is None:
             raise AttributeError(
-                "The pipeline is not registered to a scheduler")
+                'The pipeline is not registered to a scheduler')
 
         assert inputs.size == 1
         g = GraphContext(0, self._graph_repr)
@@ -61,6 +63,19 @@ class Pipeline:
         _, data = inputs.get(0, 1)
         g(data[0])
         return g.result()
+
+    def fill_cache(self):
+        """
+        Check to see if the operator directory exists locally or if needs to
+        downloaded from hub
+        """
+        for key, value in self._graph_repr.operators.items():
+            if key not in ('_start_op', '_end_op'):
+                operator_path = LOCAL_OPERATOR_CACHE / (value.function)
+                if operator_path.is_dir() is False:
+                    print('missing', operator_path)
+                else:
+                    print('has', operator_path)
 
     # @property
     # def graph_contexts(self):

--- a/towhee/engine/task_executor.py
+++ b/towhee/engine/task_executor.py
@@ -53,7 +53,7 @@ class TaskExecutor(threading.Thread):
         return self._task_queue.size
 
     def is_op_available(self, task: Task) -> bool:
-        return self._op_pool.is_op_availble(task)
+        return self._op_pool.is_op_available(task)
 
     # def set_op_parallelism(self, name: str, parallel: int = 1):
     #     """

--- a/towhee/tests/mock_operators/pytorch_transform_operator/pytorch_transform_operator.py
+++ b/towhee/tests/mock_operators/pytorch_transform_operator/pytorch_transform_operator.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import NamedTuple
+from typing import NamedTuple, Union
+
+import numpy as np
+from PIL import Image
 import torch
 from torchvision import transforms
 
@@ -20,11 +23,12 @@ from towhee.operator import Operator
 
 
 class PytorchTransformOperator(Operator):
-    """
-    Image transform operator
-        Args:
-            tfms(transforms.Compose):
-                This is used to transform an image.
+    """Uses PyTorch to transform an image (resize, crop, normalize, etc...)
+
+    Args:
+        size: (`int`)
+            Image size to use. A resize to `size x size` followed by center crop and
+            image normalization will be done.
     """
 
     def __init__(self, size: int) -> None:
@@ -36,6 +40,8 @@ class PytorchTransformOperator(Operator):
                                         transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
                                         ])
 
-    def __call__(self, img_tensor: torch.Tensor) -> NamedTuple('Outputs', [('img_transformed', torch.Tensor)]):
+    def __call__(self, img_tensor: Union[np.ndarray, Image.Image, torch.Tensor]) -> NamedTuple('Outputs', [('img_transformed', torch.Tensor)]):
+        if isinstance(img_tensor, Image.Image):
+            img_tensor = img_tensor.convert('RGB')
         Outputs = NamedTuple('Outputs', [('img_transformed', torch.Tensor)])
         return Outputs(self.tfms(img_tensor).unsqueeze(0))

--- a/towhee/utils/handler_mixin.py
+++ b/towhee/utils/handler_mixin.py
@@ -50,6 +50,10 @@ class HandlerMixin:
                 for h in self._handlers:
                     h(*args)
 
+            @property
+            def handlers(self):
+                return self._handlers
+
         self._handler_mgrs = []
 
         for prefix in handler_prefix:
@@ -61,6 +65,8 @@ class HandlerMixin:
                 self.__setattr__(add_handler_method_name, handler_mgr.add_handler)
                 call_handler_method_name = 'call_' + prefix + '_handlers'
                 self.__setattr__(call_handler_method_name, handler_mgr.call_handlers)
+                handler_getter_name = prefix + '_handlers'
+                self.__setattr__(handler_getter_name, handler_mgr.handlers)
             else:
                 raise AttributeError(
                     '`HandlerMixin` can only take `str` as handler prefix, but found %s.'


### PR DESCRIPTION
Checking cache and downloading from hub in operator_loader will cause multiple file downloads if more than one device in the system. Instead check and download during pipeline creation. Logic for checking is there, just need to figure out how we will be storing in hub.

Quick fix for https://github.com/towhee-io/towhee/issues/154 by checking if any data is given. Future work can check if the data matches the input data type, for now a log error msg is created rather than raising an error for not using the correct data type, causing an IndexingError later on. 