### PR TITLE
Automatically convert non-RGB images in embedding pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Towhee provides pre-built computer vision models which can be used to generate e
 >>> from PIL import Image
 
 # Use our in-built embedding pipeline
->>> img = Image.open('towhee_logo.png').convert('RGB')
+>>> img = Image.open('towhee_logo.png')
 >>> embedding_pipeline = pipeline('image-embedding')
 >>> embedding = embedding_pipeline(img)
 ```
@@ -51,8 +51,8 @@ Your image embedding is now stored in `embedding`. It's that simple.
 Custom machine learning pipelines can be defined in a YAML file and uploaded to the Towhee hub (coming soon&trade;). Pipelines which already exist in the local Towhee cache (`/$HOME/.towhee/pipelines`) will be automatically loaded:
 
 ```python
-# This will load the pipeline defined at $HOME/.towhee/pipelines/fzliu/resnet50-embedding.yaml
->>> embedding_pipeline = pipeline('fzliu/resnet50-embedding')
+# This will load the pipeline defined at $HOME/.towhee/pipelines/fzliu/resnet50_embedding.yaml
+>>> embedding_pipeline = pipeline('fzliu/resnet50_embedding')
 >>> embedding = embedding_pipeline(img)
 ```
 

--- a/towhee/engine/task_executor.py
+++ b/towhee/engine/task_executor.py
@@ -53,7 +53,7 @@ class TaskExecutor(threading.Thread):
         return self._task_queue.size
 
     def is_op_available(self, task: Task) -> bool:
-        return self._op_pool.is_op_availble(task)
+        return self._op_pool.is_op_available(task)
 
     # def set_op_parallelism(self, name: str, parallel: int = 1):
     #     """

--- a/towhee/tests/mock_operators/pytorch_transform_operator/pytorch_transform_operator.py
+++ b/towhee/tests/mock_operators/pytorch_transform_operator/pytorch_transform_operator.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import NamedTuple
+from typing import NamedTuple, Union
+
+import numpy as np
+from PIL import Image
 import torch
 from torchvision import transforms
 
@@ -20,11 +23,12 @@ from towhee.operator import Operator
 
 
 class PytorchTransformOperator(Operator):
-    """
-    Image transform operator
-        Args:
-            tfms(transforms.Compose):
-                This is used to transform an image.
+    """Uses PyTorch to transform an image (resize, crop, normalize, etc...)
+
+    Args:
+        size: (`int`)
+            Image size to use. A resize to `size x size` followed by center crop and
+            image normalization will be done.
     """
 
     def __init__(self, size: int) -> None:
@@ -36,6 +40,8 @@ class PytorchTransformOperator(Operator):
                                         transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
                                         ])
 
-    def __call__(self, img_tensor: torch.Tensor) -> NamedTuple('Outputs', [('img_transformed', torch.Tensor)]):
+    def __call__(self, img_tensor: Union[np.ndarray, Image.Image, torch.Tensor]) -> NamedTuple('Outputs', [('img_transformed', torch.Tensor)]):
+        if isinstance(img_tensor, Image.Image):
+            img_tensor = img_tensor.convert('RGB')
         Outputs = NamedTuple('Outputs', [('img_transformed', torch.Tensor)])
         return Outputs(self.tfms(img_tensor).unsqueeze(0))


### PR DESCRIPTION
To avoid forcing the user to first convert `PIL.Image.Image` images to RGB before running the pipeline, we do so automatically in the PyTorch preprocessing operator.