### PR TITLE
Adding optional 'branch' param in pipeline yaml.

### DIFF
--- a/towhee/dag/operator_repr.py
+++ b/towhee/dag/operator_repr.py
@@ -33,6 +33,8 @@ class OperatorRepr(BaseRepr):
             This operator's output dataframe.
         iter_info (`Dict[str, Any]`):
             This operator's iterator info.
+        branch (`str`):
+            This operators branch version from hub.
     """
     def __init__(
         self,
@@ -41,10 +43,12 @@ class OperatorRepr(BaseRepr):
         init_args: Dict[str, Any],
         inputs: List[Dict[str, Any]],
         outputs: List[Dict[str, Any]],
-        iter_info: Dict[str, Any]
+        iter_info: Dict[str, Any],
+        branch: str
     ):
         super().__init__(name)
         self._function = function
+        self._branch = branch
         self._inputs = inputs
         self._outputs = outputs
         self._init_args = init_args
@@ -53,6 +57,10 @@ class OperatorRepr(BaseRepr):
     @property
     def function(self):
         return self._function
+
+    @property
+    def branch(self):
+        return self._branch
 
     @property
     def inputs(self) -> List[dict]:
@@ -106,4 +114,12 @@ class OperatorRepr(BaseRepr):
         if not BaseRepr.is_valid(info, {'name', 'init_args', 'function', 'inputs', 'outputs', 'iter_info'}):
             raise ValueError('Invalid operator info.')
 
-        return OperatorRepr(info['name'], info['function'], info['init_args'], info['inputs'], info['outputs'], info['iter_info'])
+        return OperatorRepr(
+            info['name'],
+            info['function'],
+            info['init_args'],
+            info['inputs'],
+            info['outputs'],
+            info['iter_info'],
+            info.get('branch', 'main')
+        )

--- a/towhee/engine/operator_context.py
+++ b/towhee/engine/operator_context.py
@@ -143,7 +143,7 @@ class OperatorContext(HandlerMixin):
 
     def _create_new_task(self, inputs: Dict[str, any]):
         t = Task(self.name, self._repr.function,
-                 self._repr.init_args, inputs, self._task_idx)
+                 self._repr.init_args, inputs, self._task_idx, self._repr.branch)
         self._task_idx += 1
         t.add_task_finish_handler(self.task_finish_handlers)
         return t

--- a/towhee/engine/operator_loader.py
+++ b/towhee/engine/operator_loader.py
@@ -40,16 +40,20 @@ class OperatorLoader:
         else:
             self._cache_path = Path(cache_path)
 
-    def load_operator(self, function: str, args: Dict[str, Any]) -> Operator:
+    def load_operator(self, function: str, args: Dict[str, Any], branch: str) -> Operator:
         """Attempts to load an operator from cache. If it does not exist, looks up the
         operator in a remote location and downloads it to cache instead. By standard
         convention, the operator must be called `Operator` and all associated data must
         be contained within a single directory.
 
         Args:
-            function: (`str`)
+            function (`str`):
                 Origin and method/class name of the operator. Used to look up the proper
                 operator in cache.
+            args (`str):
+                The init_args for the operator.
+            branch (`str`):
+                Which repo branch for the hub operator.
         """
 
         if function in ['_start_op', '_end_op']:
@@ -62,7 +66,7 @@ class OperatorLoader:
         #   |_ /home/user/.towhee/operators/organization-name/operator-name/config.json
         # If file not there or force_download set to true, install operator
 
-        fname, path = self._download_operator(function)
+        fname, path = self._download_operator(function, branch)
 
         #still checking if file exists since 'local' operators arent checked for
         if path.is_file():
@@ -89,7 +93,7 @@ class OperatorLoader:
     # Figure out where to put branch info, needed for loading diff versions.
     # Currently not thread safe when downloading same repo, will most likely result in race
     # There are issues of where to to assign force_download since it may be called multiple times
-    def _download_operator(self, task, branch: str = 'main', force_download: bool = False, install_reqs: bool = True):
+    def _download_operator(self, task, branch: str, force_download: bool = False, install_reqs: bool = True):
         """Checks cache and downloads operator if necessary.
         """
         task_split = task.split('/')

--- a/towhee/engine/operator_pool.py
+++ b/towhee/engine/operator_pool.py
@@ -63,7 +63,7 @@ class OperatorPool:
         # dictionary.
         op_key = task.op_key
         if op_key not in self._all_ops:
-            op = self._op_loader.load_operator(task.hub_op_id, task.op_args)
+            op = self._op_loader.load_operator(task.hub_op_id, task.op_args, task.branch)
             op.key = op_key
         else:
             op = self._all_ops[op_key]

--- a/towhee/engine/task.py
+++ b/towhee/engine/task.py
@@ -44,14 +44,17 @@ class Task(HandlerMixin):
         task_idx:
             A new task will be constructed for each operator call. The tasks
             are indexed individually for each operation performed, starting from 0.
+        branch (`str`):
+            The hub branch for the operator.
     """
 
     def __init__(self, op_name: str, hub_op_id: str, op_args: Dict[str, Any],
-                 inputs: Dict[str, Any], task_idx: int):
+                 inputs: Dict[str, Any], task_idx: int, branch: str):
         self._op_name = op_name
         self._hub_op_id = hub_op_id
         self._op_args = op_args
         self._inputs = inputs
+        self._branch = branch
         self._task_idx = task_idx
 
         self._outputs = None
@@ -62,6 +65,10 @@ class Task(HandlerMixin):
     @property
     def op_name(self) -> str:
         return self._op_name
+
+    @property
+    def branch(self) -> str:
+        return self._branch
 
     @property
     def hub_op_id(self) -> str:
@@ -102,7 +109,7 @@ class Task(HandlerMixin):
             args_tup = tuple(sorted(self._op_args.items()))
         else:
             args_tup = ()
-        return (self._hub_op_id, ) + args_tup
+        return (self._hub_op_id, self._branch, ) + args_tup
 
     def execute(self, op: Operator = None):
         """Given a corresponding `Operator` from the `TaskExecutor`, run the task.

--- a/towhee/tests/emulated_pipelines/emulated_pipeline.py
+++ b/towhee/tests/emulated_pipelines/emulated_pipeline.py
@@ -52,7 +52,7 @@ class EmulatedPipeline:
         tasks = []
         for n in range(n_tasks):
             num = self._task_idx + n
-            task = Task('test', hub_op_id, args, {'num': num}, num)
+            task = Task('test', hub_op_id, args, {'num': num}, num, 'main')
             self._add_task_handlers(task)
             tasks.append(task)
         self._task_idx += n_tasks

--- a/towhee/tests/engine/test_engine.py
+++ b/towhee/tests/engine/test_engine.py
@@ -49,7 +49,8 @@ class TestEngine(unittest.TestCase):
                 {'name': 'num', 'df': '_start_df', 'col': 0}
             ],
             outputs=[{'df': 'op_test_in'}],
-            iter_info={'type': 'map'}
+            iter_info={'type': 'map'},
+            branch='main'
         )
 
         add_op_repr = OperatorRepr(
@@ -60,7 +61,8 @@ class TestEngine(unittest.TestCase):
                 {'name': 'num', 'df': 'op_test_in', 'col': 0}
             ],
             outputs=[{'df': 'op_test_out'}],
-            iter_info={'type': 'map'}
+            iter_info={'type': 'map'},
+            branch='main'
         )
 
         end_op_repr = OperatorRepr(
@@ -71,7 +73,8 @@ class TestEngine(unittest.TestCase):
                 {'name': 'sum', 'df': 'op_test_out', 'col': 0}
             ],
             outputs=[{'df': '_end_df'}],
-            iter_info={'type': 'map'}
+            iter_info={'type': 'map'},
+            branch='main'
         )
 
         df_start_repr = DataFrameRepr(

--- a/towhee/tests/engine/test_operator_context.py
+++ b/towhee/tests/engine/test_operator_context.py
@@ -41,7 +41,8 @@ class TestOperatorContext(unittest.TestCase):
                 {'name': 'k2', 'df': 'op_test_in', 'col': 1}
             ],
             outputs=[{'df': 'op_test_out'}],
-            iter_info={'type': 'map'}
+            iter_info={'type': 'map'},
+            branch='main'
         )
 
         op = OperatorContext(op_repr, dfs)
@@ -81,7 +82,8 @@ class TestOperatorContext(unittest.TestCase):
                 {'name': 'k2', 'df': 'op_test_in', 'col': 1}
             ],
             outputs=[{'df': 'op_test_out'}],
-            iter_info={'type': 'map'}
+            iter_info={'type': 'map'},
+            branch='main'
         )
 
         op = OperatorContext(op_repr, dfs)

--- a/towhee/tests/engine/test_operator_pool.py
+++ b/towhee/tests/engine/test_operator_pool.py
@@ -36,7 +36,7 @@ class TestOperatorPool(unittest.TestCase):
     def test_acquire_release(self):
 
         hub_op_id = 'mock_operators/add_operator'
-        task = Task('test', hub_op_id, {'factor': 0}, (1), 0)
+        task = Task('test', hub_op_id, {'factor': 0}, (1), 0, 'main')
 
         # Acquire the operator.
         op = self._op_pool.acquire_op(task)

--- a/towhee/tests/engine/test_task.py
+++ b/towhee/tests/engine/test_task.py
@@ -41,7 +41,7 @@ class TestTask(unittest.TestCase):
         args = {'arg1': 1, 'arg2': 'test'}
         inputs = {'k1': 1, 'k2': 'v1'}
         mock_output = MockOutputsWriter()
-        task = Task('mock_op', 'mock_op', args, inputs, 0)
+        task = Task('mock_op', 'mock_op', args, inputs, 0, 'main')
         task.add_task_finish_handler(mock_output.write)
         self.assertEqual(task.op_name, 'mock_op')
         self.assertEqual(task.inputs, inputs)

--- a/towhee/tests/engine/test_task_executor.py
+++ b/towhee/tests/engine/test_task_executor.py
@@ -42,9 +42,9 @@ class TestTaskExecutor(unittest.TestCase):
         tasks = []
         hub_op_id = 'mock_operators/add_operator'
         args = {'factor': 0}
-        tasks.append(Task('test', hub_op_id, args, {'num': 0}, 0))
-        tasks.append(Task('test', hub_op_id, args, {'num': 1}, 1))
-        tasks.append(Task('test', hub_op_id, args, {'num': 10}, 10))
+        tasks.append(Task('test', hub_op_id, args, {'num': 0}, 0, 'main'))
+        tasks.append(Task('test', hub_op_id, args, {'num': 1}, 1, 'main'))
+        tasks.append(Task('test', hub_op_id, args, {'num': 10}, 10, 'main'))
 
         # Add finish callbacks and submit the tasks to the executor.
         for task in tasks:
@@ -61,9 +61,9 @@ class TestTaskExecutor(unittest.TestCase):
         # Create a couple of tasks to execute through the executor.
         tasks = []
         hub_op_id = 'mock_operators/sub_operator'
-        tasks.append(Task('test', hub_op_id, {}, {'a': 0, 'b': 0}, 0))
-        tasks.append(Task('test', hub_op_id, {}, {'a': 10, 'b': 20}, 1))
-        tasks.append(Task('test', hub_op_id, {}, {'a': 23, 'b': -1}, 24))
+        tasks.append(Task('test', hub_op_id, {}, {'a': 0, 'b': 0}, 0, 'main'))
+        tasks.append(Task('test', hub_op_id, {}, {'a': 10, 'b': 20}, 1, 'main'))
+        tasks.append(Task('test', hub_op_id, {}, {'a': 23, 'b': -1}, 24, 'main'))
 
         # Add finish callbacks and submit the tasks to the executor.
         for task in tasks:


### PR DESCRIPTION
These changes add the optional branch param in the pipeline yamls. This branch is later propagated throughout and attached to the operator_repr and task so that it can be used in operator_loader. Next step is to figure out how to keep track of different downloaded versions of an operator