### PR TITLE
Install dependency via requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+torch>=1.2.0
+torchvision>=0.4.0
+numpy>=1.19.5
+pandas>=1.1.5
+pyyaml>=5.3.0
+requests>=2.12.5
+tqdm>=4.59.0
+pillow>=8.3.1
+scipy>=1.5.3
+opencv-python>=4.5.3.56

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install
 import unittest
 from pathlib import Path
+from typing import List
 
 
 def test_suite():
@@ -28,35 +29,20 @@ def create_towhee_cache(dst: str):
         Path(dst).mkdir(parents=True)
 
 
-class PostInstallCommand(install):
-    def run(self):
-        from towhee.engine import LOCAL_OPERATOR_CACHE, LOCAL_PIPELINE_CACHE
-        install.run(self)
-        create_towhee_cache(LOCAL_PIPELINE_CACHE)
-        create_towhee_cache(LOCAL_OPERATOR_CACHE)
+def parse_requirements(file_name: str) -> List[str]:
+    with open(file_name) as f:
+        return [require.strip() for require in f if require.strip() and not require.startswith("#")]
 
 
 setup(
     name="towhee",
-    version="0.2.0",
+    version="0.2.1",
     description="",
     author="Towhee Team",
     author_email="towhee-team@zilliz.com",
     url="https://github.com/towhee-io/towhee",
     test_suite="setup.test_suite",
-    cmdclass={'install': PostInstallCommand},
-    install_requires=[
-        'torch>=1.2.0',
-        'torchvision>=0.4.0',
-        'numpy>=1.19.5',
-        'pandas>=1.1.5',
-        'pyyaml>=5.3.0',
-        'requests>=2.12.5',
-        'tqdm>=4.59.0',
-        'pillow>=8.3.1',
-        'scipy>=1.5.3',
-        'opencv-python>=4.5.3.56',
-    ],
+    install_requires=parse_requirements('requirements.txt'),
     packages=find_packages(),
     package_data={'towhee.tests.test_util': ['*.yaml']},
     license="http://www.apache.org/licenses/LICENSE-2.0",


### PR DESCRIPTION
Remove requirements in setup.py, use requirements.txt instead.

~~This change will cause failure when run CodeCov.~~

~~Fixed CodeCov failure by add `pip instal -r requirements.txt` before running CodeCov~~

Load dependencies from requirements.txt