### PR TITLE
Rename TANSFORME to TRANSFORM

### DIFF
--- a/towhee/tests/mock_operators/__init__.py
+++ b/towhee/tests/mock_operators/__init__.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import os
 import sys
 import importlib
 import logging
 
-
 _MOCK_OPERATOR_DIR = os.path.dirname(__file__)
-
 
 ADD_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "add_operator")
 SUB_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "sub_operator")
@@ -28,9 +25,8 @@ PYTORCH_CNN_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "pytorch_cnn_operat
 PYTORCH_IMAGE_CLASSIFICATION_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "pytorch_image_classification_operator")
 PYTORCH_OBJECT_DETECTION_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "pytorch_object_detection_operator")
 PYTORCH_TRANSFORMER_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "pytorch_transformer_operator")
-PYTORCH_TRANSFORME_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "pytorch_transform_operator")
+PYTORCH_TRANSFORM_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "pytorch_transform_operator")
 PYTORCH_TRANSFORMER_VEC_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "pytorch_transformer_vec_operator")
-
 
 
 def load_local_operator(op_name: str, op_path: str):
@@ -41,11 +37,6 @@ def load_local_operator(op_name: str, op_path: str):
         sys.path.insert(0, op_path)
         return importlib.import_module(op_name)
     except ModuleNotFoundError as e:
-        logging.error(
-            "import model: {op_name} from path: {op_path} failed, error: {err}",
-            op_name=op_name,
-            op_path=op_path,
-            err=str(e)
-        )
+        logging.error("import model: {op_name} from path: {op_path} failed, error: {err}", op_name=op_name, op_path=op_path, err=str(e))
     finally:
         sys.path.pop(0)

--- a/towhee/tests/operators/test_pytorch_transform_operator.py
+++ b/towhee/tests/operators/test_pytorch_transform_operator.py
@@ -12,28 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import unittest
 from PIL import Image
 from torchvision import transforms
 import os
 
-from towhee.tests.mock_operators import PYTORCH_TRANSFORME_OPERATOR_PATH, load_local_operator
+from towhee.tests.mock_operators import PYTORCH_TRANSFORM_OPERATOR_PATH, load_local_operator
 
 
 class PytorchTransformTest(unittest.TestCase):
     pwd = os.getcwd()
-    test_dir = pwd+'/towhee/tests/models/vit/'
+    test_dir = pwd + '/towhee/tests/models/vit/'
     img = Image.open(test_dir + 'img.jpg')
-    tfms = transforms.Compose([transforms.Resize(256),
-                               transforms.CenterCrop(224),
-                               transforms.ToTensor(),
-                               transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
-                               ])
+    tfms = transforms.Compose(
+        [
+            transforms.Resize(256),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+        ]
+    )
     img1 = tfms(img).unsqueeze(0)
 
     def test_transform_operator(self):
-        trans = load_local_operator('pytorch_transform_operator', PYTORCH_TRANSFORME_OPERATOR_PATH)
+        trans = load_local_operator('pytorch_transform_operator', PYTORCH_TRANSFORM_OPERATOR_PATH)
         op = trans.PytorchTransformOperator(256)
         outputs = op(self.img)
         print(type(outputs.img_transformed))


### PR DESCRIPTION
Rename Typo `TRANSFORME` to `TRANSFORM` in several places.