### PR TITLE
Fix path problem in test_download

### DIFF
--- a/towhee/tests/hub/test_download.py
+++ b/towhee/tests/hub/test_download.py
@@ -4,7 +4,7 @@ from PIL import Image
 from shutil import rmtree
 from towhee import pipeline
 
-cache_path = Path(__file__).parent.resolve()
+cache_path = Path(__file__).parent.parent.resolve()
 
 
 class TestDownload(unittest.TestCase):


### PR DESCRIPTION
We had the problem of creating an unexpected `towhee` folder in `tests` folder when running `test_download.py`. 

This PR fix this problem by change the cache_path to remove the correct folder after test.