### PR TITLE
Singleton Filemanager

### DIFF
--- a/towhee/__init__.py
+++ b/towhee/__init__.py
@@ -22,7 +22,8 @@ from towhee.dataframe import Variable
 from towhee.engine.engine import Engine, EngineConfig, start_engine
 from towhee.engine.pipeline import Pipeline
 from towhee.engine import LOCAL_PIPELINE_CACHE
-from towhee.utils.hub_tools import download_repo
+from towhee.hub.hub_tools import download_repo
+from towhee.hub.file_manager import FileManagerConfig, FileManager
 
 __all__ = ['DEFAULT_PIPELINES', 'pipeline']
 
@@ -88,56 +89,11 @@ class _PipelineWrapper:
         return res
 
 
-def _get_pipeline_cache(cache_path: str):
-    if not cache_path:
-        cache_path = os.environ.get(_PIPELINE_CACHE_ENV) if os.environ.get(_PIPELINE_CACHE_ENV) else LOCAL_PIPELINE_CACHE
-    return Path(cache_path)
-
 
 # def _get_hello_towhee_pipeline():
 #     return Path(__file__).parent / 'tests/test_util/resnet50_embedding.yaml'
 
-
-def _download_pipeline(cache_path: str, task: str, branch: str = 'main', force_download: bool = False):
-    """
-    Do the check and download logic for pipelines.
-
-    In Towhee all the pipelines' name should follow the format of 'author/pipeline'.
-    """
-    task_split = task.split('/')
-
-    # For now assuming all piplines will be classifed as 'author/repo'.
-    if len(task_split) != 2:
-        raise ValueError(
-            '''Incorrect pipeline name format, should be '<author>/<pipeline_repo>', if local file please place into 'local/<pipeline_dir> '''
-        )
-
-    author = task_split[0]
-    repo = task_split[1]
-    author_path = cache_path / author
-    repo_path = author_path / repo
-    yaml_path = repo_path / (repo + '.yaml')
-
-    # Avoid downloading logic if its a fully local repo.
-    if author == 'local':
-        return yaml_path
-
-    download = False
-    if repo_path.is_dir():
-        if force_download or not yaml_path.is_file():
-            rmtree(repo_path)
-            download = True
-    else:
-        download = True
-
-    if download:
-        print('Downloading Pipeline: ' + repo)
-        download_repo(author, repo, branch, str(repo_path))
-
-    return yaml_path
-
-
-def pipeline(task: str, cache: str = None, force_download: bool = False):
+def pipeline(task: str, fmc: FileManagerConfig = FileManagerConfig(), branch: str = 'main', force_download: bool = False):
     """
     Entry method which takes either an input task or path to an operator YAML.
 
@@ -147,8 +103,10 @@ def pipeline(task: str, cache: str = None, force_download: bool = False):
     Args:
         task (`str`):
             Task name or YAML file location to use.
-        cache (`str`):
-            Cache path to use.
+        fmc (`FileManagerConfig`):
+            Optional file manager config for the local instance, defaults to local cache.
+        branch (`str`):
+            Which branch to use for operators/pipelines on hub, defaults to `main`.
         force_download (`bool`):
             Whether to redownload pipeline and operators.
 
@@ -156,26 +114,12 @@ def pipeline(task: str, cache: str = None, force_download: bool = False):
         (`typing.Any`)
             The `Pipeline` output.
     """
-
-    # If the task name coincides with one of the default pipelines, use the YAML
-    # specified by that default pipeline instead of trying to lookup a YAML in the hub
-    # or cache.
+    fm = FileManager(fmc)
 
     start_engine()
-    # TODO (jiangjunjie) delete when hub is ready
-    # if task.startswith('hello_towhee'):
-    #     yaml_path = _get_hello_towhee_pipeline()
-    # else:
     task = DEFAULT_PIPELINES.get(task, task)
+    yaml_path = fm.get_pipeline(task, branch, force_download)
 
-    # Get YAML path given task name. The default cache location for pipelines is
-    # $HOME/.towhee/pipelines
-    # TODO(fzliu): if pipeline is not available in cache, acquire it from hub
-    cache_path = _get_pipeline_cache(cache)
-    yaml_path = _download_pipeline(cache_path, task, force_download=force_download)
-
-    if not yaml_path.is_file():
-        raise NameError(F'Can not find pipeline by name {task}')
 
     engine = Engine()
     pipeline_ = Pipeline(str(yaml_path))

--- a/towhee/engine/__init__.py
+++ b/towhee/engine/__init__.py
@@ -15,9 +15,9 @@
 
 from pathlib import Path
 
-_DEFAULT_LOCAL_CACHE_ROOT = Path.home() / '.towhee'
-LOCAL_PIPELINE_CACHE = _DEFAULT_LOCAL_CACHE_ROOT / 'pipelines'
-LOCAL_OPERATOR_CACHE = _DEFAULT_LOCAL_CACHE_ROOT / 'operators'
+DEFAULT_LOCAL_CACHE_ROOT = Path.home() / '.towhee'
+LOCAL_PIPELINE_CACHE = DEFAULT_LOCAL_CACHE_ROOT / 'pipelines'
+LOCAL_OPERATOR_CACHE = DEFAULT_LOCAL_CACHE_ROOT / 'operators'
 
 MOCK_PIPELINES = str(Path(__file__).parent.parent /
                      'tests/test_util/resnet50_embedding.yaml')

--- a/towhee/engine/operator_loader.py
+++ b/towhee/engine/operator_loader.py
@@ -16,12 +16,11 @@
 import importlib.util
 from pathlib import Path
 from typing import Any, Dict
-from shutil import rmtree
 
 from towhee.operator import Operator
 from towhee.operator.nop import NOPOperator
 from towhee.engine import LOCAL_OPERATOR_CACHE
-from towhee.utils.hub_tools import download_repo
+from towhee.hub.file_manager import FileManager
 
 
 class OperatorLoader:
@@ -50,78 +49,34 @@ class OperatorLoader:
             function: (`str`)
                 Origin and method/class name of the operator. Used to look up the proper
                 operator in cache.
+        Raises:
+            FileExistsError
+                Cannot find operator.
         """
 
         if function in ['_start_op', '_end_op']:
             return NOPOperator()
 
-        # Lookup the path for the operator in local cache. Example directory structure:
-        #  /home/user/.towhee/operators/organization-name/operator-name
-        #   |_ /home/user/.towhee/operators/organization-name/operator-name/operator.py
-        #   |_ /home/user/.towhee/operators/organization-name/operator-name/resnet.torch
-        #   |_ /home/user/.towhee/operators/organization-name/operator-name/config.json
-        # If file not there or force_download set to true, install operator
+        fm = FileManager()
+        path = fm.get_operator(function)
 
-        fname, path = self._download_operator(function)
-
-        #still checking if file exists since 'local' operators arent checked for
-        if path.is_file():
-
-            # Specify the module name and absolute path of the file that needs to be
-            # imported.
-            modname = 'towhee.operator.' + fname
-            spec = importlib.util.spec_from_file_location(
-                modname, path.resolve())
-
-            # Create the module and then execute the module in its own namespace.
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-
-            # Instantiate the operator object and return it to the caller for
-            # `load_operator`. By convention, the operator class is simply the CamelCase
-            # version of the snake_case operator.
-            op_cls = ''.join(x.capitalize() or '_' for x in fname.split('_'))
-            return getattr(module, op_cls)(**args)
-
-        else:
-            raise FileNotFoundError('Operator definition not found')
-
-    # Figure out where to put branch info, needed for loading diff versions.
-    # Currently not thread safe when downloading same repo, will most likely result in race
-    # There are issues of where to to assign force_download since it may be called multiple times
-    def _download_operator(self, task, branch: str = 'main', force_download: bool = False, install_reqs: bool = True):
-        """Checks cache and downloads operator if necessary.
-        """
-        task_split = task.split('/')
-
-        # For now assuming all operators will be classifed as 'author/repo'
-        if len(task_split) != 2:
-            raise ValueError(
-                    '''Incorrect operator name format, should be '<author>/<operator_repo>' or 'local/<operator_repo>' ''')
-
-        author = task_split[0]
-        repo = task_split[1]
-        author_path = self._cache_path / author
-        repo_path = author_path / repo
-        file_path = repo_path / (repo + '.py')
+        if path is None:
+            raise FileExistsError('Cannot find operator.')
 
 
-        # for now assuming local repos will be stored in local, change once figure out where to store it
-        if author == 'local':
-            return repo, file_path
+        fname = str(path).rsplit('/', maxsplit=1)[-1][:-3]
+        modname = 'towhee.operator.' + fname
 
-        download = False
+        spec = importlib.util.spec_from_file_location(
+            modname, path.resolve())
 
-        # Check if .py exists or if we need to redownload
-        if repo_path.is_dir():
-            if force_download or not file_path.is_file():
-                rmtree(repo_path)
-                download = True
-        else:
-            download = True
+        # Create the module and then execute the module in its own namespace.
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
 
-        if download:
-            print('Downloading Operator: ' + repo)
-            download_repo(author, repo, branch, str(repo_path), install_reqs=install_reqs)
+        # Instantiate the operator object and return it to the caller for
+        # `load_operator`. By convention, the operator class is simply the CamelCase
+        # version of the snake_case operator.
+        op_cls = ''.join(x.capitalize() or '_' for x in fname.split('_'))
+        return getattr(module, op_cls)(**args)
 
-        return repo, file_path

--- a/towhee/hub/file_manager.py
+++ b/towhee/hub/file_manager.py
@@ -63,21 +63,30 @@ class FileManagerConfig():
     @property
     def cache_pipelines(self):
         return self._cache_pipelines
-    
+
     @property
     def operator_lock(self):
         return self._operators_lock
-    
+
     @property
     def pipeline_lock(self):
         return self._pipelines_lock
 
     def change_default_cache(self, default_path: Union[str, Path]):
+        """
+        Change the default cache path.
+
+        Args:
+            insert_path (`str` | `Path`):
+                The new default cache.
+        """
         default_path = Path(default_path)
         with self._paths_lock and self._default_lock:
-            if not self._cache_paths:
+            if not self._cache_paths or self._cache_paths[-1] != self._default_cache:
                 self._cache_paths.append(default_path)
-            self._cache_paths[-1] = default_path
+            else:
+                self._cache_paths[-1] = default_path
+
             self._default_cache = default_path
 
 
@@ -107,9 +116,10 @@ class FileManagerConfig():
             remove_path (`str` | `Path | `list[str | Path]`):
                 The path that you are trying to remove. Accepts multiple inputs at once.
         """
+        if not isinstance(remove_path, list):
+            remove_path = [remove_path]
+
         with self._paths_lock:
-            if not isinstance(remove_path, list):
-                remove_path = [remove_path]
             for path in remove_path:
                 try:
                     self._cache_paths.remove(Path(path))
@@ -144,7 +154,7 @@ class FileManagerConfig():
             if cache is None:
                 with self._default_lock:
                     cache = self._default_cache
-            for  paths in path:
+            for paths in path:
                 op = {}
                 op['path'] = Path(paths)
                 op['name'] = op['path'].name

--- a/towhee/hub/file_manager.py
+++ b/towhee/hub/file_manager.py
@@ -1,0 +1,393 @@
+# Copyright 2021 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+from pathlib import Path
+from typing import Union, List
+from shutil import copy2, copytree, rmtree
+
+
+from towhee.engine.singleton import singleton
+from towhee.engine import DEFAULT_LOCAL_CACHE_ROOT
+from towhee.hub.hub_tools import download_repo
+
+@singleton
+class FileManagerConfig():
+    """
+    Global FileManager config
+
+    This class dictates which cache locations to look through and in what order to check
+    for files. This config is ultimately used with FileManager.
+
+    Args:
+        set_default_cache (`str` | `Path`):
+            The default cache to check in, if nothing supplied, the default cache of $HOME/.towhee
+            will be used.
+    """
+
+    def __init__(self):
+        # TODO: #1 Deal with specifying cache priority per pipeline?
+        self._default_cache = DEFAULT_LOCAL_CACHE_ROOT
+        self._cache_paths = [DEFAULT_LOCAL_CACHE_ROOT]
+        self._cache_operators = []
+        self._cache_pipelines = []
+
+        self._default_lock = threading.Lock()
+        self._paths_lock = threading.Lock()
+        self._operators_lock = threading.Lock()
+        self._pipelines_lock = threading.Lock()
+
+    @property
+    def default_cache(self):
+        return self._default_cache
+
+    @property
+    def cache_paths(self):
+        return self._cache_paths
+
+    @property
+    def cache_operators(self):
+        return self._cache_operators
+
+    @property
+    def cache_pipelines(self):
+        return self._cache_pipelines
+    
+    @property
+    def operator_lock(self):
+        return self._operators_lock
+    
+    @property
+    def pipeline_lock(self):
+        return self._pipelines_lock
+
+    def change_default_cache(self, default_path: Union[str, Path]):
+        default_path = Path(default_path)
+        with self._paths_lock and self._default_lock:
+            if not self._cache_paths:
+                self._cache_paths.append(default_path)
+            self._cache_paths[-1] = default_path
+            self._default_cache = default_path
+
+
+    def add_cache_path(self, insert_path: Union[str, Path, List[Union[str, Path]]]):
+        """
+        Add a cache location to the front. Most recently added paths will be
+        checked first.
+
+        Args:
+            insert_path (`str` | `Path | `list[str | Path]`):
+                The path that you are trying to add. Accepts multiple inputs at once.
+        """
+        with self._paths_lock:
+            if not isinstance(insert_path, list):
+                insert_path = [insert_path]
+
+            for path in insert_path:
+                if str(path) not in [str(x) for x in self._cache_paths]:
+                    self._cache_paths.insert(0, Path(path))
+
+    # Pretty useless now but might be worth having in the future
+    def remove_cache_path(self, remove_path: Union[str, Path, List[Union[str, Path]]]):
+        """
+        Remove a cache location.
+
+        Args:
+            remove_path (`str` | `Path | `list[str | Path]`):
+                The path that you are trying to remove. Accepts multiple inputs at once.
+        """
+        with self._paths_lock:
+            if not isinstance(remove_path, list):
+                remove_path = [remove_path]
+            for path in remove_path:
+                try:
+                    self._cache_paths.remove(Path(path))
+                except ValueError:
+                    # TODO: Log this instead of print.
+                    print(str(Path(path)) + ' not found.')
+
+    def reset_cache_path(self):
+        """
+        Remove all cache locations.
+
+        """
+        self._cache_paths = [self._default_cache]
+
+    def cache_local_operator(self, path: Union[str, Path, List[Union[str, Path]]], overwrite: bool = True, cache: Union[str, Path] = None):
+        """
+        Add a local operator to a cache. In order for operators to be visible to Towhee
+        they need to be cached.
+
+        Args:
+            path (`str` | `Path | `list[str | Path]`):
+                The path to the operator or its directory.
+            overwrite (`bool`):
+                Whether to overwrite already existing operator in cache.
+            cache (`str` | `Path`):
+                Optional location to cache the opeartor.
+        """
+        if not isinstance(path, list):
+            path = [path]
+
+        with self._operators_lock:
+            if cache is None:
+                with self._default_lock:
+                    cache = self._default_cache
+            for  paths in path:
+                op = {}
+                op['path'] = Path(paths)
+                op['name'] = op['path'].name
+                op['cache'] = Path(cache)
+                op['overwrite'] = overwrite
+
+                if op not in self._cache_operators:
+                    self._cache_operators.append(op)
+
+    def cache_local_pipeline(self, path: Union[str, Path, List[Union[str, Path]]], overwrite: bool = True, cache: Union[str, Path] = None):
+        """
+        Add a local pipeline to a cache. In order for pipelines to be visible to Towhee
+        they need to be cached.
+
+        Args:
+            path (`str` | `Path | `list[str | Path]`):
+                The path to the pipeline or its directory.
+            overwrite (`bool`):
+                Whether to overwrite already existing operator in cache.
+            cache (`str` | `Path`):
+                Optional location to cache the opeartor.
+        """
+        if not isinstance(path, list):
+            path = [path]
+
+        with self._pipelines_lock:
+            if cache is None:
+                with self._default_lock:
+                    cache = self._default_cache
+            for paths in path:
+                op = {}
+                op['path'] = Path(paths)
+                op['name'] = op['path'].name
+                op['cache'] = Path(cache)
+                op['overwrite'] = overwrite
+
+                if op not in self._cache_pipelines:
+                    self._cache_pipelines.append(op)
+
+    def __str__(self):
+        return str(self.__dict__)
+
+
+@singleton
+class FileManager():
+    """
+    The filemanager for the current instance of Towhee. In charge of dealing with multiple
+    cache locations, downloading from hub, and importing local files.
+
+    Args:
+        fmc (`FileManagerConfig`):
+            Accepts an optional FileManager config, once a FileManagerConfig is selected,
+            it cannot be changed for the current runtime.
+    """
+    def __init__(self, fmc: FileManagerConfig = FileManagerConfig()):
+        self._config = fmc
+        # TODO: #1 seperate ranking for different pipelines?
+        # self._pipelines = []
+        self._operator_lock = threading.Lock()
+        self._pipeline_lock = threading.Lock()
+        self._cache_locals()
+
+
+    # Move to a utils location?
+    def _cache_name(self, name: str, author: str, branch: str):
+        # If pointing directly to pipeline file.
+        if name.endswith('.yaml'):
+            return name[:-5] + '&' + author + '$' + branch
+        # If pointing directly to operator file.
+        elif name.endswith('.py'):
+            return name[:-3] + '&' + author + '$' + branch
+        else:
+            return name + '&' + author + '$' + branch
+
+    # TODO: filip-halt
+    # Decide if to treat pipelines and operators the same. Should we allow single .py
+    # for opeartor and should we allow directory for pipeline.
+    def _cache_locals(self):
+        with self._pipeline_lock and self._config.pipeline_lock:
+            for pipe in self._config.cache_pipelines:
+                new_dir = self._cache_name(pipe['name'], author='local', branch='main')
+                file = pipe['name']
+                cache_path = pipe['cache']
+                old_path = pipe['path']
+                new_path = cache_path / new_dir / file
+
+                if pipe['overwrite']:
+                    Path.unlink(new_path, missing_ok=True)
+
+                if new_path.is_file():
+                    # TODO: filip-halt
+                    # Error logging.
+                    print('Did not overwrite.')
+                else:
+                    # TODO: filip-halt
+                    # Figure out exception types.
+                    new_path.parent.mkdir(parents=True, exist_ok=True)
+                    copy2(str(old_path), str(new_path))
+
+        with self._operator_lock:
+            for op in self._config.cache_operators:
+                new_dir = self._cache_name(op['name'], author='local', branch='main')
+                cache_path = op['cache']
+                old_path = op['path']
+                new_path = cache_path / new_dir
+
+                if op['overwrite'] and new_path.is_dir():
+                    rmtree(new_path)
+
+                if new_path.is_dir():
+                    # TODO: filip-halt
+                    # Error logging.
+                    print('Did not overwrite.')
+                else:
+                    # TODO: Figure out exception types
+                    copytree(str(old_path), str(new_path))
+
+    def get_pipeline(self, pipeline: str, branch: str = 'main', redownload: bool = False, install_reqs = True):
+        """
+        Obtain the path to the requested pipeline.
+
+        This function will obtain the first reference to the pipeline from the cache locations.
+        If no pipeline is found, this function will download it to the default cache location
+        from hub.towhee.io.
+
+        Args:
+            pipeline (`str`):
+                The pipeline in 'author/repo' format. Author will be 'local' if locally imported.
+            branch (`str`):
+                Which branch version to use of the pipeline. Branch will be 'main' if locally imported.
+            redownload (`bool`):
+                Whether to delete and redownload the pipeline files
+            install_reqs (`bool`):
+                Whether to download the python packages if a requirements.txt file is included in the repo.
+
+        Returns:
+            (Path | None)
+                Returns the path of the pipeline, None if a local pipeline isnt found.
+
+        Raises:
+            (`ValueError`):
+                Incorrect pipeline format.
+        """
+        with self._pipeline_lock:
+            pipeline_split = pipeline.split('/')
+            # For now assuming all piplines will be classifed as 'author/repo'.
+            if len(pipeline_split) != 2:
+                raise ValueError(
+                    '''Incorrect pipeline format, should be '<author>/<pipeline_repo>'.'''
+                )
+            author = pipeline_split[0]
+            repo = pipeline_split[1]
+
+            pipeline_path = self._cache_name(repo, author, branch) + '/' + repo + '.yaml'
+
+            file_path = self._config.default_cache / pipeline_path
+            found_existing = False
+
+            for path in self._config.cache_paths:
+                path = path / pipeline_path
+                if path.is_file():
+                    file_path = path
+                    found_existing = True
+                    break
+
+            if author == 'local':
+                if found_existing is False:
+                    # TODO: filip-halt
+                    # Error logging.
+                    print('Local file not found, has it been imported?')
+                    file_path = None
+            else:
+                if redownload:
+                    # TODO: filip-halt
+                    # Error logging.
+                    rmtree(file_path.parent)
+
+                if file_path.is_file() is False:
+                    download_repo(author, repo, branch, str(file_path.parent), install_reqs=install_reqs)
+
+        return file_path
+
+    def get_operator(self, operator: str, branch: str = 'main', redownload: bool = False, install_reqs = True):
+        """
+        Obtain the path to the requested operator.
+
+        This function will obtain the first reference to the operator from the cache locations.
+        If no opeartor is found, this function will download it to the default cache location
+        from hub.towhee.io.
+
+        Args:
+            operator (`str`):
+                The operator in 'author/repo' format. Author will be 'local' if locally imported.
+            branch (`str`):
+                Which branch version to use of the opeartor. Branch will be 'main' if locally imported.
+            redownload (`bool`):
+                Whether to delete and redownload the operator files
+            install_reqs (`bool`):
+                Whether to download the python packages if a requirements.txt file is included in the repo.
+
+        Returns:
+            (Path | None)
+                Returns the path of the operator, None if a local operator isnt found.
+
+        Raises:
+            (`ValueError`):
+                Incorrect opeartor format.
+        """
+        with self._operator_lock:
+            operator_split = operator.split('/')
+            # For now assuming all piplines will be classifed as 'author/repo'.
+            if len(operator_split) != 2:
+                raise ValueError(
+                    '''Incorrect operator format, should be '<author>/<operator_repo>'.'''
+                )
+            author = operator_split[0]
+            repo = operator_split[1]
+
+            operator_path = self._cache_name(repo, author, branch) + '/' + repo + '.py'
+
+            file_path = self._config.default_cache / operator_path
+            found_existing = False
+
+            for path in self._config.cache_paths:
+                path = path / operator_path
+                if path.is_file():
+                    file_path = path
+                    found_existing = True
+                    break
+
+            if author == 'local':
+                if found_existing is False:
+                # TODO: filip-halt
+                # Error logging.
+                    print('Local file not found, has it been imported?')
+                    file_path = None
+            else:
+                if redownload:
+                    # TODO: filip-halt
+                    # Error logging.
+                    rmtree(file_path.parent)
+
+                if file_path.is_file() is False:
+                    download_repo(author, repo, branch, str(file_path.parent), install_reqs=install_reqs)
+        return file_path
+

--- a/towhee/hub/hub_tools.py
+++ b/towhee/hub/hub_tools.py
@@ -1,0 +1,496 @@
+import requests
+import os
+import random
+import sys
+import getopt
+import time
+import subprocess
+
+from typing import List, Tuple
+from tqdm import tqdm
+from threading import Thread
+from getpass import getpass
+
+from tempfile import TemporaryFile
+from requests.auth import HTTPBasicAuth
+from requests.exceptions import HTTPError
+
+
+class Worker(Thread):
+    """
+    Worker class to realize multi-threads download.
+
+    Args:
+        url (`str`):
+            The url of the target files.
+        local_dir (`str`):
+            The local directory to download to.
+        file_name (`str`):
+            The name of the file (includes extension).
+    """
+    def __init__(self, url: str, local_dir: str, file_name: str):
+        super().__init__()
+        self.url = url
+        self.local_dir = local_dir
+        self.file_name = file_name
+
+    def run(self):
+        # Creating the directory tree to the file.
+        if not os.path.exists(os.path.dirname(self.local_dir + self.file_name)):
+            try:
+                os.makedirs(os.path.dirname(self.local_dir + self.file_name))
+            except FileExistsError:
+                pass
+            except OSError as e:
+                raise e
+
+        # Get content.
+        try:
+            r = requests.get(self.url, stream=True)
+            if r.status_code == 429:
+                time.sleep(3)
+                self.run()
+            r.raise_for_status()
+        except HTTPError as e:
+            raise e
+
+        # Create local files.
+        file_size = int(r.headers.get('content-length', 0))
+        chunk_size = 1024
+        progress_bar = tqdm(total=file_size, unit='iB', unit_scale=True, desc=f'Downloading {self.file_name}')
+        with open(self.local_dir + self.file_name, 'wb') as local_file:
+            for chunk in r.iter_content(chunk_size=chunk_size):
+                local_file.write(chunk)
+                progress_bar.update(len(chunk))
+        progress_bar.close()
+
+
+def exists(user: str, repo: str) -> bool:
+    """
+    Check if a repo exists.
+
+    Args:
+        user (`str`):
+            The author name.
+        repo (`str`):
+            The repo name.
+
+    Returns:
+        (`bool`)
+            return `True` if the repository exists, else `False`.
+    """
+    try:
+        url = f'https://hub.towhee.io/api/v1/repos/{user}/{repo}'
+        r = requests.get(url)
+        return r.status_code == 200
+    except HTTPError as e:
+        raise e
+
+
+def create_token(user: str, password: str, token_name: str) -> Tuple[int, str]:
+    """
+    Create an account verification token.
+
+    This token allows for avoiding HttpBasicAuth for subsequent calls.
+
+    Args:
+        user (`str`):
+            The account name.
+        password (`str`):
+            The account password.
+        token_name (`str`):
+            The name to be given to the token.
+
+    Returns:
+        (`Tuple[int, str]`)
+            Return the token id and the sha-1.
+
+    Raises:
+        (`HTTPError`)
+            Raise the error in request.
+    """
+    url = f'https://hub.towhee.io/api/v1/users/{user}/tokens'
+    data = {'name': token_name}
+    try:
+        r = requests.post(url, data=data, auth=HTTPBasicAuth(user, password))
+        r.raise_for_status()
+    except HTTPError as e:
+        raise e
+
+    res = r.json()
+    token_id = str(res['id'])
+    token_sha1 = str(res['sha1'])
+
+    return token_id, token_sha1
+
+
+def delete_token(user: str, password: str, token_id: int) -> None:
+    """
+    Delete the token with the given name. Useful for cleanup after changes.
+
+    Args:
+        user (`str`);
+            The account name.
+        password (`str`):
+            The account password.
+        token_id (`int`):
+            The token id.
+    """
+    url = f'https://hub.towhee.io/api/v1/users/{user}/tokens/{token_id}'
+    try:
+        r = requests.delete(url, auth=HTTPBasicAuth(user, password))
+        r.raise_for_status()
+    except HTTPError as e:
+        raise e
+
+
+def create_repo(repo: str, token: str, repo_type: str) -> None:
+    """
+    Create a repo under the account connected to the passed in token.
+
+    Args:
+        repo (`str`):
+            Name of the repo to create.
+        token (`str`):
+            Account verification token.
+        repo_type (`str`):
+            Which category of repo to create, only one can be used, includes
+            ('model', 'operator', 'pipeline', 'dataset').
+
+    Raises:
+        (`HTTPError`)
+            Raise error in request.
+    """
+
+    type_dict = {'model': 1, 'operator': 2, 'pipeline': 3, 'dataset': 4}
+
+    # Commented out things in data that are breaking the creation
+    data = {
+        'auto_init': True,
+        'default_branch': 'main',
+        'description': 'This is another test repo',
+        'name': repo,
+        'private': False,
+        'template': False,
+        'trust_model': 'default',
+        'type': type_dict[repo_type]
+    }
+    url = 'https://hub.towhee.io/api/v1/user/repos'
+    try:
+        r = requests.post(url, data=data, headers={'Authorization': 'token ' + token})
+        r.raise_for_status()
+    except HTTPError as e:
+        raise e
+
+
+def delete_repo(user: str, repo: str, token: str) -> None:
+    """
+    Delete the repo under the user, values correspond to
+    https://www.hub.towhee/<user>/<repo>.
+
+    Args:
+        user (`str`):
+            The account name.
+        repo (`str`):
+            The name of the repo to be deleted.
+        token (`str`):
+            Account verification token for that user.
+
+    Raises:
+        (`HTTPError`)
+            Raise error in request.
+    """
+
+    url = f'https://hub.towhee.io/api/v1/repos/{user}/{repo}'
+    try:
+        r = requests.delete(url, headers={'Authorization': 'token ' + token})
+        r.raise_for_status()
+    except HTTPError as e:
+        raise e
+
+
+def latest_branch_commit(user: str, repo: str, branch: str) -> str:
+    """
+    Grab the latest commit for a specific branch.
+
+    Args:
+        user (`str`):
+            The account name.
+        repo (`str`):
+            The repo name.
+        branch (`str`):
+            The branch name.
+
+    Returns:
+        (`str`)
+            The branch commit hash cut down to 10 characters.
+
+    Raises:
+        (`HTTPError`)
+            Raise error in request.
+    """
+
+    url = f'https://hub.towhee.io/api/v1/repos/{user}/{repo}/commits?limit=1&page=1&sha={branch}'
+    try:
+        r = requests.get(url, allow_redirects=True)
+        r.raise_for_status()
+    except HTTPError as e:
+        raise e
+
+    res = r.json()
+
+    return res[0]['sha'][:10]
+
+
+def obtain_lfs_extensions(user: str, repo: str, branch: str) -> List[str]:
+    """
+    Download the .gitattributes file from the specified repo in order to figure out
+    which files are being tracked by git-lfs.
+
+    Lines that deal with git-lfs take on the following format:
+
+    ```
+        *.extension   filter=lfs  merge=lfs ...
+    ```
+
+    Args:
+        user (`str`):
+            The account name.
+        repo (`str`):
+            The repo name.
+        branch (`str`):
+            The branch name.
+
+    Returns:
+        (`List[str]`)
+            The list of file extentions tracked by git-lfs.
+    """
+    url = f'https://hub.towhee.io/api/v1/repos/{user}/{repo}/raw/.gitattributes?ref={branch}'
+    lfs_files = []
+
+    # Using temporary file in order to avoid double download, cleaner to not split up downloads everywhere.
+    with TemporaryFile() as temp_file:
+        try:
+            r = requests.get(url)
+            r.raise_for_status()
+        except HTTPError:
+            return lfs_files
+
+        temp_file.write(r.content)
+        temp_file.seek(0)
+
+        for line in temp_file:
+            parts = line.split()
+            # We only care if lfs filter is present.
+            if b'filter=lfs' in parts[1:]:
+                # Removing the `*` in `*.ext`, need work if filtering specific files.
+                lfs_files.append(parts[0].decode('utf-8')[1:])
+
+    return lfs_files
+
+
+def get_file_list(user: str, repo: str, commit: str) -> List[str]:
+    """
+    Get all the files in the current repo at the given commit.
+
+    This is done through forming a git tree recursively and filtering out all the files.
+
+    Args:
+        user (`str`):
+            The account name.
+        repo (`str`):
+            The repo name.
+        commit (`str`):
+            The commit to base current existing files.
+
+    Returns:
+        (`List[str]`)
+            The file paths for the repo
+
+    Raises:
+        (`HTTPError`)
+            Raise error in request.
+    """
+
+    url = f'https://hub.towhee.io/api/v1/repos/{user}/{repo}/git/trees/{commit}?recursive=1'
+    file_list = []
+    try:
+        r = requests.get(url)
+        r.raise_for_status()
+    except HTTPError as e:
+        raise e
+
+    res = r.json()
+    # Check each object in the tree
+    for file in res['tree']:
+        # Ignore directories (they have the type 'tree')
+        if file['type'] != 'tree':
+            file_list.append(file['path'])
+
+    return file_list
+
+
+def download_files(user: str, repo: str, branch: str, file_list: List[str], lfs_files: List[str], local_dir: str, install_reqs: bool) -> None:
+    """
+    Download the files from hub. One url is used for git-lfs files and another for the other files.
+
+    Args:
+        user (`str`):
+            The account name.
+        repo (`str`):
+            The repo name.
+        branch (`str`):
+            The branch name.
+        file_list (`List[str]`):
+            The hub file paths.
+        lfs_files (`List[str]`):
+            The file extensions being tracked by git-lfs.
+        local_dir (`str`):
+            The local directory to download to.
+        install_reqs (`bool`):
+            Whether to install packages from requirements.txt
+
+    Raises:
+        (`HTTPError`)
+            Rasie error in request.
+        (`OSError`)
+            Raise error in writing file.
+    """
+    threads = []
+
+    # If the trailing forward slash is missing, add it on.
+    if local_dir[-1] != '/':
+        local_dir += '/'
+
+    # endswith() can check multiple suffixes if they are a tuple.
+    lfs_files = tuple(lfs_files)
+
+    for file_name in file_list:
+        # Files dealt with lfs have a different url.
+        if file_name.endswith(lfs_files):
+            url = f'https://hub.towhee.io/{user}/{repo}/media/branch/{branch}/{file_name}'
+        else:
+            url = f'https://hub.towhee.io/api/v1/repos/{user}/{repo}/raw/{file_name}?ref={branch}'
+
+        threads.append(Worker(url, local_dir, file_name))
+        threads[-1].start()
+
+    for thread in threads:
+        thread.join()
+
+    if install_reqs and 'requirements.txt' in file_list:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-r', local_dir + 'requirements.txt'])
+
+
+def download_repo(user: str, repo: str, branch: str, local_dir: str, install_reqs: bool = True) -> None:
+    """
+    Performs a download of the selected repo to specified location.
+
+    First checks to see if lfs is tracking files, then finds all the filepaths
+    in the repo and lastly downloads them to the location.
+
+    Args:
+        user (`str`):
+            The account name.
+        repo (`str`):
+            The repo name.
+        branch (`str`):
+            The branch name.
+        local_dir (`str`):
+            The local directory being downloaded to
+        install_reqs (`bool`):
+            Whether to install packages from requirements.txt
+
+    Raises:
+        (`HTTPError`)
+            Raise error in request.
+        (`OSError`)
+            Raise error in writing file.
+    """
+    if not exists(user, repo):
+        raise ValueError(user + '/' + repo + ' repo doesnt exist.')
+
+    lfs_files = obtain_lfs_extensions(user, repo, branch)
+    commit = latest_branch_commit(user, repo, branch)
+    file_list = get_file_list(user, repo, commit)
+    download_files(user, repo, branch, file_list, lfs_files, local_dir, install_reqs)
+
+
+def main(argv):
+    try:
+        opts, _ = getopt.getopt(argv[1:], 'u:p:r:t:b:d:', ['create', 'delete', 'download', 'user=', 'password=', 'repo=', 'type=', 'branch=', 'dir='])
+    except getopt.GetoptError:
+        print(
+            'Usage: hub_interaction.py -<manipulate type> -u <user> -p ' +
+            '<password> -r <repository> -t <repository type> -b <download branch> -d <download directory>'
+        )
+        sys.exit(2)
+    else:
+        if argv[0] not in ['create', 'delete', 'download']:
+            print('You must specify one kind of manipulation.')
+            sys.exit(2)
+
+    user = ''
+    password = ''
+    repo = ''
+    repo_type = ''
+    branch = 'main'
+    directory = os.getcwd() + '/test_download/'
+    # TODO(Filip) figure out how to store the token
+    token_name = random.randint(0, 10000)
+    manipulation = argv[0]
+
+    for opt, arg in opts:
+        if opt in ['-u', '--user']:
+            user = arg
+        elif opt in ['-p', '--password']:
+            password = arg
+        elif opt in ['-r', '--repo']:
+            repo = arg
+        elif opt in ['-t', '--type']:
+            repo_type = arg
+        elif opt in ['-d', '--dir']:
+            directory = arg
+        elif opt in ['-r', '--repo']:
+            repo = arg
+
+    if manipulation in ('create', 'delete'):
+        if not user:
+            user = input('Please enter your username: ')
+        if not password:
+            password = getpass('Please enter your password: ')
+        if not repo:
+            repo = input('Please enter the repo name: ')
+        if not repo_type:
+            repo_type = input('Please enter the repo type, choose one from "model | operator | pipeline | dataset": ')
+
+        print('Creating token...')
+        token_id, token_hash = create_token(user, password, token_name)
+        print('token: ', token_hash)
+
+        if manipulation == 'create':
+            print('Creating repo...')
+            create_repo(repo, token_hash, repo_type)
+            print('Done')
+
+        elif manipulation == 'delete':
+            print('Deleting repo...')
+            delete_repo(user, repo, token_hash)
+            print('Done')
+
+        print('Deleting token...')
+        # TODO(Filip) right now this doesnt get done if an exception is raised before it
+        delete_token(user, password, token_id)
+        print('Done')
+
+    elif manipulation == 'download':
+        if not user:
+            user = input('Please enter the repo author: ')
+        if not repo:
+            repo = input('Please enter the repo name: ')
+        print('Downloading repo...')
+        download_repo(user, repo, branch, directory)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/towhee/tests/engine/test_engine.py
+++ b/towhee/tests/engine/test_engine.py
@@ -11,24 +11,43 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import unittest
+# from shutil import rmtree
 
 from towhee.dag.graph_repr import GraphRepr
 from towhee.dag.variable_repr import VariableRepr
 from towhee.dag.dataframe_repr import DataFrameRepr
-import unittest
-
 from towhee.engine.engine import Engine
 from towhee.engine.pipeline import Pipeline
 from towhee.dataframe import DataFrame, Variable
 from towhee.tests.test_util import SIMPLE_PIPELINE_YAML, FLATMAP_PIPELINE_YAML
 from towhee.dag import OperatorRepr
+from towhee.tests import CACHE_PATH
+from towhee.hub.file_manager import FileManagerConfig, FileManager
 
 
 class TestEngine(unittest.TestCase):
     """
     combine tests of engine/scheduler/task-executor/task
     """
+
+    @classmethod
+    def setUpClass(cls):
+        new_cache = (CACHE_PATH/'test_cache')
+        pipeline_cache = (CACHE_PATH/'test_util')
+        operator_cache = (CACHE_PATH/'mock_operators')
+        fmc = FileManagerConfig()
+        fmc.change_default_cache(new_cache)
+        pipelines = list(pipeline_cache.rglob('*.yaml'))
+        operators = [f for f in operator_cache.iterdir() if f.is_dir()]
+        fmc.cache_local_pipeline(pipelines)
+        fmc.cache_local_operator(operators)
+        fm = FileManager(fmc) # pylint: disable=unused-variable
+
+    # @classmethod
+    # def tearDownClass(cls):
+    #     new_cache = (CACHE_PATH/'test_cache')
+    #     rmtree(str(new_cache))
 
     def test_engine(self):
 
@@ -44,8 +63,8 @@ class TestEngine(unittest.TestCase):
         )
 
         add_op_repr = OperatorRepr(
-            name='mock_operators/add_operator',
-            function='mock_operators/add_operator',
+            name='local/add_operator',
+            function='local/add_operator',
             init_args={'factor': 2},
             inputs=[
                 {'name': 'num', 'df': 'op_test_in', 'col': 0}

--- a/towhee/tests/engine/test_engine.py
+++ b/towhee/tests/engine/test_engine.py
@@ -37,7 +37,7 @@ class TestEngine(unittest.TestCase):
         pipeline_cache = (CACHE_PATH/'test_util')
         operator_cache = (CACHE_PATH/'mock_operators')
         fmc = FileManagerConfig()
-        fmc.change_default_cache(new_cache)
+        fmc.update_default_cache(new_cache)
         pipelines = list(pipeline_cache.rglob('*.yaml'))
         operators = [f for f in operator_cache.iterdir() if f.is_dir()]
         fmc.cache_local_pipeline(pipelines)

--- a/towhee/tests/engine/test_operator_pool.py
+++ b/towhee/tests/engine/test_operator_pool.py
@@ -30,11 +30,10 @@ class TestOperatorPool(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         new_cache = (CACHE_PATH/'test_cache')
-        print(new_cache)
         pipeline_cache = (CACHE_PATH/'test_util')
         operator_cache = (CACHE_PATH/'mock_operators')
         fmc = FileManagerConfig()
-        fmc.change_default_cache(new_cache)
+        fmc.update_default_cache(new_cache)
         pipelines = list(pipeline_cache.rglob('*.yaml'))
         operators = [f for f in operator_cache.iterdir() if f.is_dir()]
         fmc.cache_local_pipeline(pipelines)

--- a/towhee/tests/engine/test_operator_pool.py
+++ b/towhee/tests/engine/test_operator_pool.py
@@ -15,15 +15,36 @@
 
 import unittest
 from pathlib import Path
+# from shutil import rmtree
 
 from towhee.operator import Operator
 from towhee.engine.operator_pool import OperatorPool
 from towhee.engine.task import Task
+from towhee.tests import CACHE_PATH
+from towhee.hub.file_manager import FileManagerConfig, FileManager
 
 
 class TestOperatorPool(unittest.TestCase):
     """Basic test case for `OperatorPool`.
     """
+    @classmethod
+    def setUpClass(cls):
+        new_cache = (CACHE_PATH/'test_cache')
+        print(new_cache)
+        pipeline_cache = (CACHE_PATH/'test_util')
+        operator_cache = (CACHE_PATH/'mock_operators')
+        fmc = FileManagerConfig()
+        fmc.change_default_cache(new_cache)
+        pipelines = list(pipeline_cache.rglob('*.yaml'))
+        operators = [f for f in operator_cache.iterdir() if f.is_dir()]
+        fmc.cache_local_pipeline(pipelines)
+        fmc.cache_local_operator(operators)
+        fm = FileManager(fmc) # pylint: disable=unused-variable
+
+    # @classmethod
+    # def tearDownClass(cls):
+    #     new_cache = (CACHE_PATH/'test_cache')
+    #     rmtree(str(new_cache))
 
     def setUp(self):
         cache_path = Path(__file__).parent.parent.resolve()
@@ -35,7 +56,7 @@ class TestOperatorPool(unittest.TestCase):
 
     def test_acquire_release(self):
 
-        hub_op_id = 'mock_operators/add_operator'
+        hub_op_id = 'local/add_operator'
         task = Task('test', hub_op_id, {'factor': 0}, (1), 0)
 
         # Acquire the operator.

--- a/towhee/tests/engine/test_pipeline.py
+++ b/towhee/tests/engine/test_pipeline.py
@@ -35,7 +35,7 @@ class TestPipeline(unittest.TestCase):
         pipeline_cache = (CACHE_PATH/'test_util')
         operator_cache = (CACHE_PATH/'mock_operators')
         fmc = FileManagerConfig()
-        fmc.change_default_cache(new_cache)
+        fmc.update_default_cache(new_cache)
         pipelines = list(pipeline_cache.rglob('*.yaml'))
         operators = [f for f in operator_cache.iterdir() if f.is_dir()]
         fmc.cache_local_pipeline(pipelines)

--- a/towhee/tests/engine/test_pipeline.py
+++ b/towhee/tests/engine/test_pipeline.py
@@ -12,34 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-from pathlib import Path
+# import os
+# from pathlib import Path
 import unittest
 
 
 from PIL import Image
+# from shutil import rmtree
 
-from towhee import pipeline, _get_pipeline_cache, _PIPELINE_CACHE_ENV
+from towhee import pipeline
 from towhee.tests import CACHE_PATH
+from towhee.hub.file_manager import FileManagerConfig, FileManager
 
 
 class TestPipeline(unittest.TestCase):
     """
     Tests `pipeline` functionality.
     """
+    @classmethod
+    def setUpClass(cls):
+        new_cache = (CACHE_PATH/'test_cache')
+        pipeline_cache = (CACHE_PATH/'test_util')
+        operator_cache = (CACHE_PATH/'mock_operators')
+        fmc = FileManagerConfig()
+        fmc.change_default_cache(new_cache)
+        pipelines = list(pipeline_cache.rglob('*.yaml'))
+        operators = [f for f in operator_cache.iterdir() if f.is_dir()]
+        fmc.cache_local_pipeline(pipelines)
+        fmc.cache_local_operator(operators)
+        fm = FileManager(fmc) # pylint: disable=unused-variable
+
+    # @classmethod
+    # def tearDownClass(cls):
+    #     new_cache = (CACHE_PATH/'test_cache')
+    #     rmtree(str(new_cache))
 
     def test_empty_input(self):
-        p = pipeline('test_util/simple_pipeline', cache=str(CACHE_PATH))
+        p = pipeline('local/simple_pipeline')
         self.assertEqual(p(), [])
 
     def test_simple_pipeline(self):
-        p = pipeline('test_util/simple_pipeline', cache=str(CACHE_PATH))
+        p = pipeline('local/simple_pipeline')
         res = p(0)
         self.assertEqual(res[0], 3)
 
     def test_embedding_pipeline(self):
-        p = pipeline('test_util/resnet50_embedding',
-                     cache=str(CACHE_PATH))
+        p = pipeline('local/resnet50_embedding')
         img_path = CACHE_PATH / 'data' / 'dataset' / 'kaggle_dataset_small' / \
             'train' / '0021f9ceb3235effd7fcde7f7538ed62.jpg'
         img = Image.open(str(img_path))
@@ -48,25 +66,23 @@ class TestPipeline(unittest.TestCase):
 
     def test_simple_pipeline_multirow(self):
         #pylint: disable=protected-access
-        p = pipeline('test_util/simple_pipeline', cache=str(CACHE_PATH))
+        p = pipeline('local/simple_pipeline')
         p._pipeline.parallelism = 2
         res = p(list(range(1000)))
         for n in range(1000):
             self.assertEqual(res[n], n+3)
 
+# class TestPipelineCache(unittest.TestCase):
+#     def test_pipeline_cache(self):
+#         self.assertEqual(_get_pipeline_cache(
+#             None), Path.home() / '.towhee/pipelines')
 
-class TestPipelineCache(unittest.TestCase):
-    def test_pipeline_cache(self):
-        self.assertEqual(_get_pipeline_cache(
-            None), Path.home() / '.towhee/pipelines')
+#         os.environ[_PIPELINE_CACHE_ENV] = '/opt/.pipeline'
+#         self.assertEqual(_get_pipeline_cache(
+#             None), Path('/opt/.pipeline'))
 
-        os.environ[_PIPELINE_CACHE_ENV] = '/opt/.pipeline'
-        self.assertEqual(_get_pipeline_cache(
-            None), Path('/opt/.pipeline'))
-
-        self.assertEqual(_get_pipeline_cache(
-            '/home/mycache'), Path('/home/mycache'))
-
+#         self.assertEqual(_get_pipeline_cache(
+#             '/home/mycache'), Path('/home/mycache'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/towhee/tests/engine/test_task_executor.py
+++ b/towhee/tests/engine/test_task_executor.py
@@ -22,9 +22,6 @@ from towhee.engine.task import Task
 from towhee.hub.file_manager import FileManagerConfig, FileManager
 from towhee.tests import CACHE_PATH
 
-import os
-
-
 class TestTaskExecutor(unittest.TestCase):
     """Basic test case for `TaskExecutor`.
     """
@@ -34,16 +31,13 @@ class TestTaskExecutor(unittest.TestCase):
         new_cache = (CACHE_PATH/'test_cache')
         pipeline_cache = (CACHE_PATH/'test_util')
         operator_cache = (CACHE_PATH/'mock_operators')
-        print(new_cache)
         fmc = FileManagerConfig()
-        fmc.change_default_cache(new_cache)
+        fmc.update_default_cache(new_cache)
         pipelines = list(pipeline_cache.rglob('*.yaml'))
         operators = [f for f in operator_cache.iterdir() if f.is_dir()]
         fmc.cache_local_pipeline(pipelines)
         fmc.cache_local_operator(operators)
         fm = FileManager(fmc) # pylint: disable=unused-variable
-        x = os.listdir(str(new_cache))
-        print(x)
 
     # @classmethod
     # def tearDownClass(cls):

--- a/towhee/tests/engine/test_task_executor.py
+++ b/towhee/tests/engine/test_task_executor.py
@@ -15,14 +15,40 @@
 
 from pathlib import Path
 import unittest
+# from shutil import rmtree
 
 from towhee.engine.task_executor import TaskExecutor
 from towhee.engine.task import Task
+from towhee.hub.file_manager import FileManagerConfig, FileManager
+from towhee.tests import CACHE_PATH
+
+import os
 
 
 class TestTaskExecutor(unittest.TestCase):
     """Basic test case for `TaskExecutor`.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        new_cache = (CACHE_PATH/'test_cache')
+        pipeline_cache = (CACHE_PATH/'test_util')
+        operator_cache = (CACHE_PATH/'mock_operators')
+        print(new_cache)
+        fmc = FileManagerConfig()
+        fmc.change_default_cache(new_cache)
+        pipelines = list(pipeline_cache.rglob('*.yaml'))
+        operators = [f for f in operator_cache.iterdir() if f.is_dir()]
+        fmc.cache_local_pipeline(pipelines)
+        fmc.cache_local_operator(operators)
+        fm = FileManager(fmc) # pylint: disable=unused-variable
+        x = os.listdir(str(new_cache))
+        print(x)
+
+    # @classmethod
+    # def tearDownClass(cls):
+    #     new_cache = (CACHE_PATH/'test_cache')
+    #     rmtree(str(new_cache))
 
     def setUp(self):
         cache_path = Path(__file__).parent.parent.resolve()
@@ -40,7 +66,7 @@ class TestTaskExecutor(unittest.TestCase):
 
         # Create a couple of tasks to execute through the executor.
         tasks = []
-        hub_op_id = 'mock_operators/add_operator'
+        hub_op_id = 'local/add_operator'
         args = {'factor': 0}
         tasks.append(Task('test', hub_op_id, args, {'num': 0}, 0))
         tasks.append(Task('test', hub_op_id, args, {'num': 1}, 1))
@@ -60,7 +86,7 @@ class TestTaskExecutor(unittest.TestCase):
 
         # Create a couple of tasks to execute through the executor.
         tasks = []
-        hub_op_id = 'mock_operators/sub_operator'
+        hub_op_id = 'local/sub_operator'
         tasks.append(Task('test', hub_op_id, {}, {'a': 0, 'b': 0}, 0))
         tasks.append(Task('test', hub_op_id, {}, {'a': 10, 'b': 20}, 1))
         tasks.append(Task('test', hub_op_id, {}, {'a': 23, 'b': -1}, 24))

--- a/towhee/tests/hub/test_download.py
+++ b/towhee/tests/hub/test_download.py
@@ -1,8 +1,13 @@
 import unittest
 from pathlib import Path
 from PIL import Image
-from shutil import rmtree
+# from shutil import rmtree
+
 from towhee import pipeline
+from towhee.hub.file_manager import FileManagerConfig, FileManager
+from towhee.tests import CACHE_PATH
+
+
 
 cache_path = Path(__file__).parent.parent.resolve()
 
@@ -11,12 +16,25 @@ class TestDownload(unittest.TestCase):
     """
     Simple hub download and run test.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        new_cache = (CACHE_PATH/'test_cache')
+        pipeline_cache = (CACHE_PATH/'test_util')
+        operator_cache = (CACHE_PATH/'mock_operators')
+        fmc = FileManagerConfig()
+        fmc.change_default_cache(new_cache)
+        pipelines = list(pipeline_cache.rglob('*.yaml'))
+        operators = [f for f in operator_cache.iterdir() if f.is_dir()]
+        fmc.cache_local_pipeline(pipelines)
+        fmc.cache_local_operator(operators)
+        fm = FileManager(fmc) # pylint: disable=unused-variable
+
     def test_pipeline(self):
-        p = pipeline('towhee/ci_test', cache=str(cache_path), force_download=True)
-        img = Image.open(str(cache_path / 'towhee/ci_test/towhee_logo.png'))
+        p = pipeline('towhee/ci_test')
+        img = Image.open(CACHE_PATH / 'test_cache/ci_test&towhee$main/towhee_logo.png')
         res = p(img)
         self.assertEqual(res[0].size, 1000)
-        rmtree(str(cache_path) + '/towhee')
 
 
 if __name__ == '__main__':

--- a/towhee/tests/hub/test_download.py
+++ b/towhee/tests/hub/test_download.py
@@ -23,7 +23,7 @@ class TestDownload(unittest.TestCase):
         pipeline_cache = (CACHE_PATH/'test_util')
         operator_cache = (CACHE_PATH/'mock_operators')
         fmc = FileManagerConfig()
-        fmc.change_default_cache(new_cache)
+        fmc.update_default_cache(new_cache)
         pipelines = list(pipeline_cache.rglob('*.yaml'))
         operators = [f for f in operator_cache.iterdir() if f.is_dir()]
         fmc.cache_local_pipeline(pipelines)

--- a/towhee/tests/test_util/resnet50_embedding/resnet50_embedding.yaml
+++ b/towhee/tests/test_util/resnet50_embedding/resnet50_embedding.yaml
@@ -16,7 +16,7 @@ operators:
             type: map
     -
         name: 'preprocessing'
-        function: 'mock_operators/pytorch_transform_operator'
+        function: 'local/pytorch_transform_operator'
         init_args:
             size: 256
         inputs:
@@ -31,7 +31,7 @@ operators:
             type: map
     -
         name: 'embedding_model'
-        function: 'mock_operators/pytorch_cnn_operator'
+        function: 'local/pytorch_cnn_operator'
         init_args:
             model_name: 'resnet50'
         inputs:

--- a/towhee/tests/test_util/simple_pipeline/simple_pipeline.yaml
+++ b/towhee/tests/test_util/simple_pipeline/simple_pipeline.yaml
@@ -16,7 +16,7 @@ operators:
             type: map
     -
         name: 'add_op1'
-        function: 'mock_operators/add_operator'
+        function: 'local/add_operator'
         init_args:
             factor: 1
         inputs:
@@ -31,7 +31,7 @@ operators:
             type: map
     -
         name: 'add_op2'
-        function: 'mock_operators/add_operator'
+        function: 'local/add_operator'
         init_args:
             factor: 2
         inputs:

--- a/towhee/tests/test_util/test_flatmap/flatmap_pipeline.yaml
+++ b/towhee/tests/test_util/test_flatmap/flatmap_pipeline.yaml
@@ -16,7 +16,7 @@ operators:
             type: map
     -
         name: 'flat_op'
-        function: 'mock_operators/repeat_operator'
+        function: 'local/repeat_operator'
         init_args:
             repeat: 5
         inputs:


### PR DESCRIPTION
Moves to a singleton FileManager that allows multiple cache locations, caching of local operators/pipelines, and downloading of the same operator/pipeline from different branches.

Two main additions:

File Manager Config (optional):

One per runtime
Specify the cache locations to look for and their order
Specify which local operators/pipelines to put into which cache location
File Manager:

On creation, load all specified operators into their respective caches
get_operator(): look through cache locations for operator. If not found, download from hub to default cache. If local operator not found, skip downloading from hub and return None.
get_pipeline(): Same interaction as get opeartor, just for pipelines.