### PR TITLE
Allow specifying framework either in YAMl or in pipeline args

### DIFF
--- a/towhee/__init__.py
+++ b/towhee/__init__.py
@@ -76,20 +76,20 @@ class _PipelineWrapper:
         return res
 
 
-def pipeline(task: str, fmc: FileManagerConfig = FileManagerConfig(), branch: str = 'main', force_download: bool = False):
+def pipeline(src: str, branch: str = 'main', framework: str = 'pytorch', force_download: bool = False):
     """
-    Entry method which takes either an input task or path to an operator YAML.
+    Entry method which takes either an input task name or path to an operator YAML.
 
-    A `Pipeline` object is created (based on said task) and subsequently added to the
+    A `Pipeline` object is created (based on the src) and subsequently added to the
     existing `Engine`.
 
     Args:
-        task (`str`):
+        src (`str`):
             Task name or YAML file location to use.
-        fmc (`FileManagerConfig`):
-            Optional file manager config for the local instance, defaults to local cache.
         branch (`str`):
             Which branch to use for operators/pipelines on hub, defaults to `main`.
+        framework (`str`):
+            The framework to apply.
         force_download (`bool`):
             Whether to redownload pipeline and operators.
 
@@ -99,14 +99,16 @@ def pipeline(task: str, fmc: FileManagerConfig = FileManagerConfig(), branch: st
     """
     start_engine()
 
-    if os.path.isfile(task):
-        yaml_path = task
+    if os.path.isfile(src):
+        yaml_path = src
     else:
+        fmc = FileManagerConfig()
         fm = FileManager(fmc)
-        task = DEFAULT_PIPELINES.get(task, task)
-        yaml_path = fm.get_pipeline(task, branch, force_download)
+        src = DEFAULT_PIPELINES.get(src, src)
+        yaml_path = fm.get_pipeline(src, branch, force_download)
 
     engine = Engine()
+    engine.framework = framework
     pipeline_ = Pipeline(str(yaml_path))
     engine.add_pipeline(pipeline_)
 

--- a/towhee/engine/pipeline.py
+++ b/towhee/engine/pipeline.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Union
 
 from towhee.dag.graph_repr import GraphRepr
 from towhee.dataframe import DataFrame
@@ -24,16 +25,15 @@ class Pipeline:
     The runtime pipeline context, include graph context, all dataframes.
 
     Args:
-        graph_repr: (`str` or `towhee.dag.GraphRepr`)
-            The graph representation either as a YAML-formatted string, or directly
-            as an instance of `GraphRepr`.
-        parallelism: (`int`)
+        graph_repr (`Union[towhee.dag.GraphRepr, str]`):
+            The graph representation loaed as a YAML-formatted string, or directly
+            as an instance of `GraphRepr`, or the path leads to the YAML file.
+        parallelism (`int`):
             The parallelism parameter dictates how many copies of the graph context
             we create. This is likely a low number (1-4) for local engines, but may
             be much higher for cloud instances.
     """
-
-    def __init__(self, graph_repr: GraphRepr, parallelism: int = 1) -> None:
+    def __init__(self, graph_repr: Union[GraphRepr, str], parallelism: int = 1) -> None:
         self._parallelism = parallelism
         self.on_graph_finish_handlers = []
         self._scheduler = None

--- a/towhee/operator/__init__.py
+++ b/towhee/operator/__init__.py
@@ -11,11 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from towhee.operator.base import Operator, NNOperator, PyOperator, SharedType
 
-
-from towhee.operator.base import Operator, SharedType
-
-__all__ = [
-    "Operator",
-    "SharedType"
-]
+__all__ = ['Operator', 'NNOperator', 'PyOperator', 'SharedType']

--- a/towhee/operator/base.py
+++ b/towhee/operator/base.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from abc import abstractmethod
 from abc import ABC
 from enum import Enum
-
 
 # NotShareable:
 #    Stateful & reusable operator.
@@ -42,16 +40,12 @@ class Operator(ABC):
                 Outputs = NamedTuple("Outputs", [("sum", int)])
                 return Outputs(self._factor + num)
     """
-
     @abstractmethod
     def __init__(self):
         """
         Init operator, before a graph starts, the framework will call Operator __init__ function.
 
         Args:
-
-        Returns:
-            None
 
         Raises:
             An exception during __init__ can terminate the graph run.
@@ -65,9 +59,7 @@ class Operator(ABC):
 
         Args:
 
-
-        Return:
-            NamedTuple
+        Returns:
 
         Raises:
             An exception during __init__ can terminate the graph run.
@@ -87,10 +79,40 @@ class Operator(ABC):
         self._key = value
 
 
-class PyTorchNNOperator(Operator):
+class NNOperator(Operator):
     """
-    PyTorch model operator base
+    Neural Network related operators that involve machine learning frameworks.
+
+    Args:
+        framework (`str`):
+            The framework to apply.
     """
+    def __init__(self, framework: str = 'pytorch'):
+        super().__init__()
+        self._framework = framework
+
+    @property
+    def framework(self):
+        return self._framework
+
+    @framework.setter
+    def framework(self, framework: str):
+        self._framework = framework
+
+    def train(self):
+        """
+        For training model
+        """
+        raise NotImplementedError
+
+
+class PyOperator(Operator):
+    """
+    Python function operator, no machine learning frameworks involved.
+    """
+    def __init__(self):
+        super().__init__()
+        pass
 
     def train(self):
         """

--- a/towhee/tests/mock_operators/__init__.py
+++ b/towhee/tests/mock_operators/__init__.py
@@ -19,14 +19,16 @@ import logging
 
 _MOCK_OPERATOR_DIR = os.path.dirname(__file__)
 
-ADD_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "add_operator")
-SUB_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "sub_operator")
-PYTORCH_CNN_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "pytorch_cnn_operator")
-PYTORCH_IMAGE_CLASSIFICATION_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "pytorch_image_classification_operator")
-PYTORCH_OBJECT_DETECTION_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "pytorch_object_detection_operator")
-PYTORCH_TRANSFORMER_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "pytorch_transformer_operator")
-PYTORCH_TRANSFORM_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "pytorch_transform_operator")
-PYTORCH_TRANSFORMER_VEC_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, "pytorch_transformer_vec_operator")
+ADD_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, 'add_operator')
+SUB_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, 'sub_operator')
+NN_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, 'nn_operator')
+PY_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, 'py_operator')
+PYTORCH_CNN_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, 'pytorch_cnn_operator')
+PYTORCH_IMAGE_CLASSIFICATION_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, 'pytorch_image_classification_operator')
+PYTORCH_OBJECT_DETECTION_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, 'pytorch_object_detection_operator')
+PYTORCH_TRANSFORMER_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, 'pytorch_transformer_operator')
+PYTORCH_TRANSFORM_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, 'pytorch_transform_operator')
+PYTORCH_TRANSFORMER_VEC_OPERATOR_PATH = os.path.join(_MOCK_OPERATOR_DIR, 'pytorch_transformer_vec_operator')
 
 
 def load_local_operator(op_name: str, op_path: str):
@@ -37,6 +39,6 @@ def load_local_operator(op_name: str, op_path: str):
         sys.path.insert(0, op_path)
         return importlib.import_module(op_name)
     except ModuleNotFoundError as e:
-        logging.error("import model: {op_name} from path: {op_path} failed, error: {err}", op_name=op_name, op_path=op_path, err=str(e))
+        logging.error('import model: {op_name} from path: {op_path} failed, error: {err}', op_name=op_name, op_path=op_path, err=str(e))
     finally:
         sys.path.pop(0)

--- a/towhee/tests/mock_operators/nn_operator/__init__.py
+++ b/towhee/tests/mock_operators/nn_operator/__init__.py
@@ -11,23 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from typing import NamedTuple
-from towhee.operator import PyOperator, SharedType
-
-
-class AddOperator(PyOperator):
-    """
-    Stateful operator
-    """
-    def __init__(self, factor: int) -> None:
-        super().__init__()
-        self._factor = factor
-
-    def __call__(self, num: int) -> NamedTuple("Outputs", [("sum", int)]):
-        Outputs = NamedTuple("Outputs", [("sum", int)])
-        return Outputs(self._factor + num)
-
-    @property
-    def shared_type(self):
-        return SharedType.Shareable

--- a/towhee/tests/mock_operators/nn_operator/nn_operator.py
+++ b/towhee/tests/mock_operators/nn_operator/nn_operator.py
@@ -12,22 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import NamedTuple
-from towhee.operator import PyOperator, SharedType
+from towhee.operator import NNOperator
 
 
-class AddOperator(PyOperator):
+class TestNNOperator(NNOperator):
     """
-    Stateful operator
+    A test NNOperator with no functionality.
     """
-    def __init__(self, factor: int) -> None:
+    def __init__(self, framework: str = 'pytorch'):
         super().__init__()
-        self._factor = factor
-
-    def __call__(self, num: int) -> NamedTuple("Outputs", [("sum", int)]):
-        Outputs = NamedTuple("Outputs", [("sum", int)])
-        return Outputs(self._factor + num)
+        self._framework = framework
 
     @property
-    def shared_type(self):
-        return SharedType.Shareable
+    def framework(self):
+        return self._framework
+
+    @framework.setter
+    def framework(self, framework: str):
+        self._framework = framework
+
+    def __call__(self):
+        print('I\'m an NNOperator.')

--- a/towhee/tests/mock_operators/py_operator/__init__.py
+++ b/towhee/tests/mock_operators/py_operator/__init__.py
@@ -11,23 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from typing import NamedTuple
-from towhee.operator import PyOperator, SharedType
-
-
-class AddOperator(PyOperator):
-    """
-    Stateful operator
-    """
-    def __init__(self, factor: int) -> None:
-        super().__init__()
-        self._factor = factor
-
-    def __call__(self, num: int) -> NamedTuple("Outputs", [("sum", int)]):
-        Outputs = NamedTuple("Outputs", [("sum", int)])
-        return Outputs(self._factor + num)
-
-    @property
-    def shared_type(self):
-        return SharedType.Shareable

--- a/towhee/tests/mock_operators/py_operator/py_operator.py
+++ b/towhee/tests/mock_operators/py_operator/py_operator.py
@@ -12,22 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import NamedTuple
-from towhee.operator import PyOperator, SharedType
+from towhee.operator import PyOperator
 
 
-class AddOperator(PyOperator):
+class TestPyOperator(PyOperator):
     """
-    Stateful operator
+    A test PyOperator with no functionality.
     """
-    def __init__(self, factor: int) -> None:
+    def __init__(self):
         super().__init__()
-        self._factor = factor
+        pass
 
-    def __call__(self, num: int) -> NamedTuple("Outputs", [("sum", int)]):
-        Outputs = NamedTuple("Outputs", [("sum", int)])
-        return Outputs(self._factor + num)
-
-    @property
-    def shared_type(self):
-        return SharedType.Shareable
+    def __call__(self):
+        print('I\'m an PyOperator.')

--- a/towhee/tests/operators/test_operator_base.py
+++ b/towhee/tests/operators/test_operator_base.py
@@ -12,23 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import unittest
 
-
-from towhee.tests.mock_operators import ADD_OPERATOR_PATH, load_local_operator
-from towhee.operator import SharedType
+from towhee.tests.mock_operators import ADD_OPERATOR_PATH, NN_OPERATOR_PATH, PY_OPERATOR_PATH, load_local_operator
+from towhee.operator import SharedType, PyOperator, NNOperator, Operator
 
 
 class TestOperator(unittest.TestCase):
     """
     Simple operator test
     """
+    def test_nnoperator(self):
+        self.assertTrue(issubclass(NNOperator, Operator))
 
-    def test_func_operator(self):
-        add_operator = load_local_operator(
-            'add_operator', ADD_OPERATOR_PATH)
+        nn_operator = load_local_operator('nn_operator', NN_OPERATOR_PATH)
+        pt_op = nn_operator.TestNNOperator()
+        tf_op = nn_operator.TestNNOperator('tensorflow')
+        self.assertIsInstance(pt_op, NNOperator)
+        self.assertIsInstance(tf_op, NNOperator)
+        self.assertEqual(pt_op.framework, 'pytorch')
+        self.assertEqual(tf_op.framework, 'tensorflow')
+
+        pt_op.framework = 'tensorflow'
+        self.assertEqual(pt_op.framework, tf_op.framework)
+
+    def test_pyoperator(self):
+        self.assertTrue(issubclass(PyOperator, Operator))
+
+        py_operator = load_local_operator('py_operator', PY_OPERATOR_PATH)
+        op = py_operator.TestPyOperator()
+
+        self.assertIsInstance(op, PyOperator)
+
+    def test_operator_function(self):
+        add_operator = load_local_operator('add_operator', ADD_OPERATOR_PATH)
         op = add_operator.AddOperator(1)
+        self.assertTrue(isinstance(op, PyOperator))
         self.assertEqual(op(1).sum, 2)
         self.assertEqual(op.shared_type, SharedType.Shareable)
 


### PR DESCRIPTION
Since we want to support framework specification in both pipeline initialization and pipeline YAML, we need to pass framework arg in operators' __init__() function and modify system code accordingly. 

1. Add arg `framework` in pipelines' __init__ function, so users can specify framework when initialize a pipeline.
2. Add a member `_framework` in `Engine` as a property, since engine is a singleton, we cannot initialize it twice, system will set engine's framework every time run a pipeline accordingly.
3. Add a member `_framework` in `ThreadPoolTaskExecutor`, same as `Engine`.
3. Judge an operator before load and execution, if it's an NNOperator, add arg `framework`.
4. Add arg `framework` in `OperatorPool.acquire_operator()`
5. Add arg `framework` in `OperatorLoader.load_operator()`
6. Move `NNOperator` and `PyOperator` to `base.py`