### PR TITLE
Fix doc broken links

### DIFF
--- a/docs/get-started/quick-start.mdx
+++ b/docs/get-started/quick-start.mdx
@@ -88,4 +88,4 @@ Once you're finished, be sure to quit out of the enviroment using:
 
 ### Try more pipelines
 
-A summary of our image embedding pipelines can be found [here](../pipelines/image-embedding). In addition, we recommend that you browse the [hub](https://towhee.io/pipelines) to find more interesting pipelines.
+A summary of our image embedding pipelines can be found [here](../pipelines/image-embedding.md). In addition, we recommend that you browse the [hub](https://towhee.io/pipelines) to find more interesting pipelines.

--- a/docs/pipelines/image-embedding.md
+++ b/docs/pipelines/image-embedding.md
@@ -7,8 +7,8 @@ Image embedding pipelines are used for reduction the dimensionality of the input
 
 ### Popular Scenarios
 
-- [Reverse image search](../tutorials/reverse-image-search)
-- [Image deduplication](../tutorials/image-deduplication)
+- [Reverse image search](../tutorials/reverse-image-search.md)
+- [Image deduplication](../tutorials/image-deduplication.md)
 - Copyright infringement detection
 - Item tagging
 - Celebrity tagging


### PR DESCRIPTION
Signed-off-by: tumao <yan.wang@zilliz.com>

Previously we used the relative link to refer other docs like following:

`[here](../pipelines/image-embedding)`

It works now but will be broken when `trailingSlash` config has been changed. So please use the relative path of the document(including extension) file to reference another doc file. For example:

`[here](../pipelines/image-embedding.md)`

You can find more about this on [docusaurus docs](https://docusaurus.io/docs/docs-markdown-features#referencing-other-documents).
