### PR TITLE
Add Operator APIs to save & load weights

### DIFF
--- a/tests/unittests/trainer/test_weights.py
+++ b/tests/unittests/trainer/test_weights.py
@@ -1,0 +1,55 @@
+# Copyright 2021 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import torch
+import torchvision
+from pathlib import Path
+
+from towhee.operator import NNOperator
+
+
+class MockOperator(NNOperator):
+    def __init__(self, model_name='resnet50', framework='pytorch'):
+        super().__init__(framework=framework)
+        self.model_name = model_name
+        self.model = torchvision.models.resnet50(pretrained=True)
+    def __call__(self, x):
+        return self.model(x)
+    def get_model(self):
+        return self.model
+
+class TestWeights(unittest.TestCase):
+    """
+    Test save_weights
+    """
+    op = MockOperator()
+    x = torch.rand([1, 3, 224, 224])
+
+    def test_weights(self):
+        self.op.save('./test_save')
+        filepath = './test_save/pytorch_weights.pth'
+        self.assertTrue(Path(filepath).is_file())
+
+        with self.assertRaises(FileExistsError):
+            self.op.save('./test_save', overwrite=False)
+
+        out1 = self.op(self.x)
+        self.op.load_weights('./test_save')
+        out2 = self.op(self.x)
+        self.assertTrue((out1==out2).all())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/towhee/trainer/dataset.py
+++ b/towhee/trainer/dataset.py
@@ -39,11 +39,12 @@ def get_dataset(name, **kwargs) -> TorchDataSet:
     """
     dataset_construct_map = {
         'mnist': datasets.MNIST,
-        'cifar10': datasets.cifar.CIFAR10
+        'cifar10': datasets.cifar.CIFAR10,
+        'fake': datasets.FakeData
         # 'imdb': IMDB  # ,()
     }
-    default_args = {'root': 'data'}
-    kwargs = {**default_args, **kwargs}
+    #default_args = {'root': 'data'}
+    #kwargs = {**default_args, **kwargs}
     torch_dataset = dataset_construct_map[name](
         **kwargs)  # , transform=transform, target_transform=target_transform, **kwargs)
     return TorchDataSet(torch_dataset)

--- a/towhee/trainer/load_weights.py
+++ b/towhee/trainer/load_weights.py
@@ -1,0 +1,21 @@
+import torch
+
+
+class LoadWeights:
+    """
+    Args:
+        device: 'cpu'
+    """
+
+    def __init__(self, device: str = 'cpu'):
+        self.device = torch.device(device)
+
+    def load_weights(self, model, weight_path):
+        device = self.device
+        weights = torch.load(weight_path, map_location=device)
+        assert isinstance(weights, dict)
+        try:
+            model.load_state_dict(weights, strict=False)
+            return model
+        except Exception as e:
+            raise e

--- a/towhee/trainer/save_weights.py
+++ b/towhee/trainer/save_weights.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import torch
+
+
+class SaveWeights:
+    """
+    Args:
+        overwrite: if or not overwrite the weights file
+    """
+
+    def __init__(self, operator: str = 'NNOperator', overwrite: bool = True):
+        self.operator = operator
+        self.overwrite = overwrite
+
+    def save_weights(self, model: object, weights_path):
+        try:
+            if not self.overwrite:
+                if Path(weights_path).exists():
+                    raise FileExistsError('File already exists: ', str(Path(weights_path).resolve()))
+            torch.save(model.state_dict(), weights_path)
+
+        except Exception as e:
+            raise e


### PR DESCRIPTION
Signed-off-by: Jael Gu <mengjia.gu@zilliz.com>

This commit works with the test operator: https://towhee.io/towhee/train-tmp-effi-b5-op (run python test.py)

1. op.save('test') will save model weights to 'test/framework_weights.pth' (eg. test/pytorch_weights.pth)
2. op.load('test') will load weights from 'test/framework_weights.pth' (eg. test/pytorch_weights.pth)