### PR TITLE
Add init_edits during pipeline creation

### DIFF
--- a/towhee/__init__.py
+++ b/towhee/__init__.py
@@ -72,7 +72,7 @@ class _PipelineWrapper:
         return format_handler(out_df)
 
 
-def pipeline(pipeline_src: str, tag: str = 'main', install_reqs: bool = True):
+def pipeline(pipeline_src: str, tag: str = 'main', install_reqs: bool = True, init_edits: dict = None):
     """
     Entry method which takes either an input task or path to an operator YAML.
 
@@ -86,6 +86,9 @@ def pipeline(pipeline_src: str, tag: str = 'main', install_reqs: bool = True):
             Which tag to use for operators/pipelines on hub, defaults to `main`.
         install_reqs (`bool`):
             Whether to download the python packages if a requirements.txt file is included in the repo.
+        init_edits (`dict`):
+            Optional argument that allows changes to operator init_args when creating a
+            pipeline. In the form of {operator_name: {param1: value1, param2: value2, ...}, ...}
 
     Returns
         (`typing.Any`)
@@ -101,7 +104,7 @@ def pipeline(pipeline_src: str, tag: str = 'main', install_reqs: bool = True):
         yaml_path = fm.get_pipeline(p_repo, tag, install_reqs)
 
     engine = Engine()
-    pipeline_ = Pipeline(str(yaml_path))
+    pipeline_ = Pipeline(str(yaml_path), init_edits = init_edits)
     engine.add_pipeline(pipeline_)
 
     return _PipelineWrapper(pipeline_)

--- a/towhee/dag/graph_repr.py
+++ b/towhee/dag/graph_repr.py
@@ -192,7 +192,7 @@ class GraphRepr(BaseRepr):
         return GraphRepr(info['name'], info.get('type', ''), operators, dataframes)
 
     @staticmethod
-    def from_yaml(src: str, init_edits: dict):
+    def from_yaml(src: str, init_edits: dict = None):
         """
         Import a YAML file describing this graph.
         Example YAML look like this:

--- a/towhee/dag/graph_repr.py
+++ b/towhee/dag/graph_repr.py
@@ -192,7 +192,7 @@ class GraphRepr(BaseRepr):
         return GraphRepr(info['name'], info.get('type', ''), operators, dataframes)
 
     @staticmethod
-    def from_yaml(src: str):
+    def from_yaml(src: str, init_edits: dict):
         """
         Import a YAML file describing this graph.
         Example YAML look like this:
@@ -225,14 +225,22 @@ class GraphRepr(BaseRepr):
         Args:
             src (`str`):
                 YAML file (could be pre-loaded as string) to import.
+            init_edits (`dict`):
+                Optional changes to the init_args of a pipeline during runtime.
+                In the form of {operator_name: {param1: value1, param2: value2, ...}, ...}
 
         Returns:
             (`towhee.dag.GraphRepr`)
                 The GraphRepr object.
         """
         info = BaseRepr.load_src(src)
-        g_repr = GraphRepr.from_dict(info)
 
+        if init_edits is not None:
+            for op in info['operators']:
+                if op['name'] in init_edits:
+                    op['init_args'] = {k: init_edits[op['name']].get(k, v) for k, v in op['init_args'].items()}
+
+        g_repr = GraphRepr.from_dict(info)
         iso_df = g_repr.get_isolated_df()
         iso_op = g_repr.get_isolated_op()
         loop = g_repr.get_loop()

--- a/towhee/engine/pipeline.py
+++ b/towhee/engine/pipeline.py
@@ -27,20 +27,23 @@ class Pipeline:
         graph_repr: (`str` or `towhee.dag.GraphRepr`)
             The graph representation either as a YAML-formatted string, or directly
             as an instance of `GraphRepr`.
+        init_edits: (`dict`)
+            Changes to operator parameters during pipeline creation. In the form of
+            {operator_name: {param1: value1, param2: value2, ...}, ...}
         parallelism: (`int`)
             The parallelism parameter dictates how many copies of the graph context
             we create. This is likely a low number (1-4) for local engines, but may
             be much higher for cloud instances.
     """
 
-    def __init__(self, graph_repr: GraphRepr, parallelism: int = 1) -> None:
+    def __init__(self, graph_repr: GraphRepr, init_edits: dict = None, parallelism: int = 1) -> None:
         self._parallelism = parallelism
         self.on_graph_finish_handlers = []
         self._scheduler = None
         self._graph_count = 0
 
         if isinstance(graph_repr, str):
-            self._graph_repr = GraphRepr.from_yaml(graph_repr)
+            self._graph_repr = GraphRepr.from_yaml(graph_repr, init_edits)
         else:
             self._graph_repr = graph_repr
 


### PR DESCRIPTION
Simple change that allows edits to operator init_args during pipeline creation. Simple usage as follows: 
```python
init_edits = {operator_name: {param1: value1, param2: value2, ...}, ...}
pipeline = towhee.pipeline('towhee/example', init_edits = init_edits)
pipeline2  = towhee.pipeline('towhee/example')
```

Signed-off-by: Filip Haltmayer <filip.haltmayer@zilliz.com>