### PR TITLE
Allow operator to resume training

### DIFF
--- a/tests/unittests/trainer/test_trainer.py
+++ b/tests/unittests/trainer/test_trainer.py
@@ -64,12 +64,17 @@ class TrainerTest(unittest.TestCase):
             prediction_loss_only=True,
         )
         self.op = MockOperator()
-        self.op.train(training_config=self.training_args,train_dataset=self.train_data)
+        self.op.train(training_config=self.training_args, train_dataset=self.train_data)
         # self.trainer = Trainer(
         #     operator=op,
         #     training_config=self.training_args,
         #     train_dataset=self.train_data
         # )
+
+    def test_resume_trainer(self):
+        self.op.set_trainer(training_config=self.training_args, train_dataset=self.train_data)
+        self.op.resume_train()
+        self.assertEqual(1, 1)
 
     def test_overfit_on_small_batches(self) -> None:
         self.op.train(training_config=self.training_args,train_dataset=self.train_data)

--- a/towhee/operator/base.py
+++ b/towhee/operator/base.py
@@ -126,7 +126,15 @@ class NNOperator(Operator):
             )
         self.trainer.train()
 
-    def set_trainer(self, training_config, train_dataset=None, eval_dataset=None):
+    def resume_train(self, last_checkpoint=None):
+        """
+        Resume training from checkpoint
+        """
+        if self.trainer is None:
+            raise ValueError(f'Invalid Trainer: {self.trainer}')
+        self.trainer.resume_from_checkpoint(last_checkpoint)
+
+    def set_trainer(self, training_config=None, train_dataset=None, eval_dataset=None):
         self.trainer = Trainer(self.get_model(), training_config, train_dataset, eval_dataset)
 
     def load(self, path: str = None):

--- a/towhee/trainer/utils/trainer_utils.py
+++ b/towhee/trainer/utils/trainer_utils.py
@@ -21,6 +21,8 @@ from typing import NamedTuple
 from enum import Enum
 import numpy as np
 import torch
+import os
+from pathlib import Path
 
 
 def set_seed(seed: int):
@@ -35,12 +37,21 @@ def set_seed(seed: int):
     torch.manual_seed(seed)
 
 
+def get_last_checkpoint(out_dir: str):
+    checkpoints = [path for path in Path(out_dir).iterdir() if path.is_dir()]
+    if len(checkpoints) == 0:
+        raise ValueError(f"No checkpoints found at {out_dir}.")
+    return max(checkpoints, key=os.path.getmtime).resolve()
+
+
 class TrainOutput(NamedTuple):
     global_step: int
     training_loss: float
 
 
 CHECKPOINT_NAME = "checkpoint.pt"
+
+
 # _re_checkpoint = re.compile(r"^" + CHECKPOINT_NAME + r"\-(\d+)$")
 
 class SchedulerType(Enum):


### PR DESCRIPTION
Signed-off-by: Jael Gu <mengjia.gu@zilliz.com>

Example use:
- op.resume_train() --> resume training from latest checkpoint directory under `output_dir` defined in `training_config`
- op.resume_train(my_dir) --> resume training from the checkpoint directory `my_dir` instead