### PR TITLE
add  `towhee.pipes` for pipeline templates

### DIFF
--- a/tests/unittests/pipelines/test_pipeline_pipes.py
+++ b/tests/unittests/pipelines/test_pipeline_pipes.py
@@ -1,0 +1,58 @@
+# Copyright 2021 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from towhee import pipes
+
+render_result = """
+name: test_pipeline
+variables:
+    test_op: 'filip-halt/timm-image-embedding'
+    model_name: 'efficientnet_b3'
+operators:
+- name: embedding_model
+  function: 'towhee/test_op'
+  tag: main
+  init_args:
+    model_name: efficientnet_b3
+  inputs:
+  - df: image
+    name: image
+    col: 0
+  outputs:
+  - df: embedding
+  iter_info:
+    type: map
+dataframes:
+- name: embedding
+  columns:
+  - name: feature_vector
+    vtype: numpy.ndarray
+""".strip()
+
+
+class TestPipelinePipes(unittest.TestCase):
+    """
+    tests for template build
+    """
+
+    def test_pipes(self):
+        # pylint: disable=protected-access
+        pipe = pipes.builtin.template_test(test_op='towhee/test_op')
+        self.assertEqual(repr(pipe), render_result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/towhee/__init__.py
+++ b/towhee/__init__.py
@@ -197,3 +197,10 @@ class _OperatorLazyWrapper:
 
 
 ops = param_scope().callholder(_OperatorLazyWrapper.callback)
+
+
+def _pipeline_callback(name, *arg, **kws):
+    name = name.replace('.', '/').replace('_', '-')
+    return Build(**kws).pipeline(name, *arg)
+
+pipes = param_scope().callholder(_pipeline_callback)


### PR DESCRIPTION
Signed-off-by: jie.hou <jie.hou@zilliz.com>

The users are able to create a pipeline instance by the following codes:
```
from towhee import pipes

pipe = pipes.towhee.image_embedding_pipeline_1way(model_name='vgg')
```

`towhee. pipes.towhee.image_embedding_pipeline_1way` will invoke the pipeline repo `towhee/image-embedding-pipeline-1way` from towhee hub. The pipeline repo will be used as a template and specialized with template variable `model_name='vgg'`.