### PR TITLE
support operator level parallel execution

### DIFF
--- a/tests/unittests/functional/test_data_collection.py
+++ b/tests/unittests/functional/test_data_collection.py
@@ -79,7 +79,7 @@ class TestDataCollection(unittest.TestCase):
         )
         self.assertListEqual(list(result), [2, 4, 6, 8, 10])
 
-    def test_example_for_multple_line_statement(self):
+    def test_example_for_multiple_line_statement(self):
         dc = DataCollection(range(5))
         result = dc \
             .myop.add(val=1) \

--- a/tests/unittests/functional/test_parallel.py
+++ b/tests/unittests/functional/test_parallel.py
@@ -1,0 +1,47 @@
+# Copyright 2021 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import doctest
+import unittest
+
+import numpy as np
+
+from towhee.functional import DataCollection
+
+import towhee.functional.mixins.parallel
+
+
+class TestParallel(unittest.TestCase):
+    """
+    tests for data collection parallel execution
+    """
+
+    def test_example_for_basic_api(self):
+        _ = (
+            DataCollection.range(50).stream() \
+                .pmap(lambda x: np.random.random((x * 20, x * 20)),3) \
+                .pmap(lambda x: np.dot(x, x), 4).to_list()
+        )
+        _ = (
+            DataCollection.range(10).stream().safe()\
+                .pmap(lambda x: np.random.random((x * 20, x * 20)), 3) \
+                .pmap(lambda x: np.dot(x, x), 4).to_list()
+        )
+
+
+TestDataCollectionParallelExecution = doctest.DocTestSuite(
+    towhee.functional.mixins.parallel)
+unittest.TextTestRunner().run(TestDataCollectionParallelExecution)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/towhee/__init__.py
+++ b/towhee/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import threading
 from typing import List, Tuple, Union
 
 from towhee.dataframe import DataFrame
@@ -220,10 +221,12 @@ class _OperatorLazyWrapper:
         self._tag = tag
         self._kws = kws
         self._op = None
+        self._lock = threading.Lock()
 
     def __call__(self, *arg, **kws):
-        if self._op is None:
-            self._op = op(self._name, self._tag, **self._kws)
+        with self._lock:
+            if self._op is None:
+                self._op = op(self._name, self._tag, **self._kws)
         return self._op(*arg, **kws)
 
     @property

--- a/towhee/functional/mixins/parallel.py
+++ b/towhee/functional/mixins/parallel.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 import concurrent.futures
 from queue import Queue
+import asyncio
+
+from towhee.functional.option import Option
+from towhee.hparam.hyperparameter import param_scope
 
 
 class ParallelMixin:
@@ -22,11 +26,44 @@ class ParallelMixin:
     Examples:
     >>> from towhee.functional import DataCollection
     >>> def add_1(x):
-    ...     x+1
+    ...     return x+1
     >>> result = DataCollection.range(1000).map(add_1).parallel(5).to_list()
     >>> len(result)
     1000
+    >>> result = DataCollection.range(1000).pmap(add_1, 10).pmap(add_1, 10).to_list()
+    >>> result[990:]
+    [992, 993, 994, 995, 996, 997, 998, 999, 1000, 1001]
     """
+
+    def __init__(self) -> None:
+        with param_scope() as hp:
+            parent = hp().data_collection.parent(None)
+        if parent is not None and hasattr(parent, '_executor') and isinstance(
+                parent._executor, concurrent.futures.ThreadPoolExecutor):
+            self.set_parallel(executor=parent._executor)
+
+    def set_parallel(self, num_worker=None, executor=None):
+        """
+        set parallel execution
+
+        Examples:
+        >>> from towhee.functional import DataCollection
+        >>> import threading
+        >>> stage_1_thread_set = set()
+        >>> stage_2_thread_set = set()
+        >>> result = (
+        ...     DataCollection.range(1000).stream().set_parallel(4)
+        ...     .map(lambda x: stage_1_thread_set.add(threading.current_thread().ident))
+        ...     .map(lambda x: stage_2_thread_set.add(threading.current_thread().ident)).to_list()
+        ... )
+        >>> len(stage_2_thread_set)
+        3
+        """
+        if executor is not None:
+            self._executor = executor
+        if num_worker is not None:
+            self._executor = concurrent.futures.ThreadPoolExecutor(num_worker)
+        return self
 
     def parallel(self, num_worker):
         executor = concurrent.futures.ThreadPoolExecutor(num_worker)
@@ -50,8 +87,67 @@ class ParallelMixin:
 
         return self.factory(inner())
 
+    def pmap(self, unary_op, num_worker=None, executor=None):
+        """
+        apply `unary_op` with parallel execution
+
+        Examples:
+        >>> from towhee.functional import DataCollection
+        >>> import threading
+        >>> stage_1_thread_set = set()
+        >>> stage_2_thread_set = set()
+        >>> result = (
+        ...     DataCollection.range(1000).stream()
+        ...     .pmap(lambda x: stage_1_thread_set.add(threading.current_thread().ident), 5)
+        ...     .pmap(lambda x: stage_2_thread_set.add(threading.current_thread().ident), 4).to_list()
+        ... )
+        >>> len(stage_1_thread_set)
+        4
+        >>> len(stage_2_thread_set)
+        3
+        """
+        if executor is None:
+            executor = concurrent.futures.ThreadPoolExecutor(num_worker)
+        num_worker = executor._max_workers  # pylint: disable=protected-access
+        queue = Queue(maxsize=num_worker)
+        loop = asyncio.new_event_loop()
+        flag = True
+
+        def make_task(x):
+
+            def task_wrapper():
+                if isinstance(x, Option):
+                    return x.map(unary_op)
+                else:
+                    return unary_op(x)
+
+            return task_wrapper
+
+        async def worker():
+            buff = []
+            for x in self:
+                if len(buff) == num_worker:
+                    queue.put(await buff.pop(0))
+                buff.append(loop.run_in_executor(executor, make_task(x)))
+            while len(buff) > 0:
+                queue.put(await buff.pop(0))
+            nonlocal flag
+            flag = False
+
+        def worker_wrapper():
+            loop.run_until_complete(worker())
+
+        executor.submit(worker_wrapper)
+
+        def inner():
+            nonlocal flag
+            while flag or not queue.empty():
+                yield queue.get()
+            # executor.shutdown()
+
+        return self.factory(inner())
+
 
 if __name__ == '__main__':  # pylint: disable=inconsistent-quotes
     import doctest
-
     doctest.testmod(verbose=False)


### PR DESCRIPTION
Signed-off-by: jie.hou <jie.hou@zilliz.com>

Initial implementation for operator level parallel execution. The following APIs is added:
1. `pmap(operator, num_worker)`: execute operator with multiple worker
```python
dc.map(lambda x: x+1) # no parallel execution
  .pmap(lambda x: x*2, 5) # execute operator with 5 workers in the parallel, keep elements order
```

2. `set_parallel(num_worker)`: setup parallel executor for chained pipeline
```python
dc.map(lambda x: x+1) # no parallel execution
  .set_parallel(5) # setup a parallel executor with 5 workers
  .map(lambda x: x*2) # execute operator in parallel with previous executor, keep elements order
  .map(lambda x: x+1) # execute this operator also in parallel
```

3. `parallel(num_worker)`: execute pipeline with multiple worker
```python
dc.map(lambda x: x+1)
  .map(lambda x: x*2)
  .parallel(5) # execute the pipeline with 5 workers in the parallel
```