### PR TITLE
Add transforms for pretrained models in pytorchvideo

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
-torch>=1.2.0
-torchvision>=0.4.0
+torch>=1.8.0
+torchvision>=0.9.0
 numpy>=1.19.5
 pandas>=1.1.5
 requests>=2.12.5

--- a/tests/unittests/models/utils/test_video_transforms.py
+++ b/tests/unittests/models/utils/test_video_transforms.py
@@ -1,0 +1,62 @@
+# Copyright 2022 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import unittest
+from towhee.models.utils.video_transforms import VideoTransforms
+
+
+
+class TestVideoTransforms(unittest.TestCase):
+    """
+    Test transforms for pretrained models in pytorchvideo
+    """
+    def setUp(self) -> None:
+        url = 'https://dl.fbaipublicfiles.com/pytorchvideo/projects/archery.mp4'
+        subprocess.check_call(['wget', url])
+
+    def test_transforms(self):
+        tfms_slow_r50 = VideoTransforms('slow_r50')
+        out_slow_r50 = tfms_slow_r50('archery.mp4')
+        self.assertEqual(out_slow_r50['video'].shape, (3, 8, 256, 256))
+        self.assertEqual(out_slow_r50['audio'].shape, (441344,))
+
+        tfms_slowfast_r50 = VideoTransforms('slowfast_r50')
+        tfms_slowfast_r101 = VideoTransforms('slowfast_r101')
+        out_slowfast_r50 = tfms_slowfast_r50('archery.mp4')
+        out_slowfast_r101 = tfms_slowfast_r101('archery.mp4')
+        self.assertEqual(out_slowfast_r50['video_slow'].shape, out_slowfast_r101['video_slow'].shape, (3, 8, 256, 256))
+        self.assertEqual(out_slowfast_r50['video_fast'].shape, out_slowfast_r101['video_fast'].shape, (3, 32, 256, 256))
+        self.assertEqual(out_slowfast_r50['audio'].shape, out_slowfast_r101['audio'].shape, (441344,))
+
+        tfms_x3d_xs = VideoTransforms('x3d_xs')
+        tfms_x3d_s = VideoTransforms('x3d_s')
+        tfms_x3d_m = VideoTransforms('x3d_m')
+        out_x3d_xs = tfms_x3d_xs('archery.mp4')
+        out_x3d_s = tfms_x3d_s('archery.mp4')
+        out_x3d_m = tfms_x3d_m('archery.mp4')
+        self.assertEqual(out_x3d_xs['video'].shape, (3, 4, 182, 182))
+        self.assertEqual(out_x3d_s['video'].shape, (3, 13, 182, 182))
+        self.assertEqual(out_x3d_m['video'].shape, (3, 16, 256, 256))
+        self.assertEqual(out_x3d_xs['audio'].shape, (441344,))
+        self.assertEqual(out_x3d_s['audio'].shape, (441344,))
+        self.assertEqual(out_x3d_m['audio'].shape, (441344,))
+
+    def tearDown(self) -> None:
+        os.unlink('archery.mp4')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)

--- a/towhee/models/utils/video_transforms.py
+++ b/towhee/models/utils/video_transforms.py
@@ -1,0 +1,162 @@
+# Original implementation by Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+#
+# Modifications by Copyright 2022 Zilliz . All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+
+import torch
+from torch import nn
+
+from torchvision.transforms import Compose, Lambda
+from torchvision.transforms._transforms_video import (
+    CenterCropVideo,
+    NormalizeVideo,
+)
+
+try:
+    from pytorchvideo.data.encoded_video import EncodedVideo
+except ModuleNotFoundError:
+    os.system('pip install "git+https://github.com/facebookresearch/pytorchvideo.git"')
+    from pytorchvideo.data.encoded_video import EncodedVideo
+from pytorchvideo.transforms import (
+    ApplyTransformToKey,
+    ShortSideScale,
+    UniformTemporalSubsample,
+    # UniformCropVideo
+)
+
+class VideoTransforms:
+    """
+    Transform video to video & audio tensors given an video path, corresponding to models by model name.
+    The code is buiil on top of examples given by [Pytorchvideo](https://pytorchvideo.org/).
+    The following model names are supported:
+        - slow_r50
+        - slowfast_r50
+        - slowfast_r101
+        - x3d_xs
+        - x3d_s
+        - x3d_m
+
+    Args:
+        model_name (`str`):
+            model name
+    Returns:
+        A dictionary including tensors for both video and audio.
+
+    Example:
+        >>> from towhee.models.utils.video_transform import VideoTransforms
+        >>> tfms = VideoTransforms("slow_r50")
+        >>> video_data = tfms(video_path="/path/to/video", start_sec=0, end_sec=30)
+    """
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+        self.tfms_params = tfms_params[model_name]
+        self.tfms = ApplyTransformToKey(
+            key="video",
+            transform=Compose([
+                    UniformTemporalSubsample(self.tfms_params["num_frames"]),
+                    Lambda(lambda x: x/255.0),
+                    NormalizeVideo(
+                        mean = [0.45, 0.45, 0.45],
+                        std = [0.225, 0.225, 0.225]
+                        ),
+                    ShortSideScale(size=self.tfms_params["side_size"]),
+                    CenterCropVideo(
+                        crop_size=(self.tfms_params["crop_size"], self.tfms_params["crop_size"])
+                        ),
+                    PackPathway(alpha=self.tfms_params["alpha"]) if model_name.startswith("slowfast") else nn.Identity()
+                    ]),
+            )
+
+    def __call__(self, video_path: str, start_sec=0, end_sec=30):
+        video = EncodedVideo.from_path(video_path)
+        video_data = video.get_clip(start_sec=start_sec, end_sec=end_sec)
+        video_data = self.tfms(video_data)
+        if isinstance(video_data["video"], list) and str(self.tfms._transform.transforms[-1]) == "PackPathway()":
+            video_data["video_slow"] = video_data["video"][0]
+            video_data["video_fast"] = video_data["video"][1]
+        return video_data
+
+
+class PackPathway(nn.Module):
+    """
+    Transform for converting video frames as a list of tensors.
+
+    Args:
+        frames (`torch.Tensor`):
+            video frames
+
+    Returns:
+        a list of tensors [slow_pathway, fast_pathway]
+    """
+    def __init__(self, alpha):
+        super().__init__()
+        self.alpha = alpha
+
+    def forward(self, frames: torch.Tensor):
+        fast_pathway = frames
+        # Perform temporal sampling from the fast pathway.
+        slow_pathway = torch.index_select(
+            frames,
+            1,
+            torch.linspace(
+                0, frames.shape[1] - 1, frames.shape[1] // self.alpha
+            ).long(),
+        )
+        frame_list = [slow_pathway, fast_pathway]
+        return frame_list
+
+
+tfms_params  = {
+    "slow_r50": {
+        "side_size": 256,
+        "crop_size": 256,
+        "num_frames": 8,
+        "sampling_rate": 8
+    },
+    "slowfast_r50": {
+        "side_size": 256,
+        "crop_size": 256,
+        "num_frames": 32,
+        "sampling_rate": 2,
+        "alpha": 4
+    },
+    "slowfast_r101": {
+        "side_size": 256,
+        "crop_size": 256,
+        "num_frames": 32,
+        "sampling_rate": 8,
+        "alpha": 4
+    },
+    "x3d_xs": {
+        "side_size": 182,
+        "crop_size": 182,
+        "num_frames": 4,
+        "sampling_rate": 12,
+    },
+    "x3d_s": {
+        "side_size": 182,
+        "crop_size": 182,
+        "num_frames": 13,
+        "sampling_rate": 6,
+    },
+    "x3d_m": {
+        "side_size": 256,
+        "crop_size": 256,
+        "num_frames": 16,
+        "sampling_rate": 5,
+    }
+}


### PR DESCRIPTION
Signed-off-by: Jael Gu <mengjia.gu@zilliz.com>

Add utils to preprocess video with transforms, configs are setup in script by model name.
Apply this utils to get video data ready for pre-trained models in torch hub:
- slow_r50
- slowfast_r50
- slowfast_r101
- x3d_xs
- x3d_s
- x3d_m