### PR TITLE
support pandas backend

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -7,7 +7,7 @@ tqdm>=4.59.0
 pillow>=8.3.1
 scipy>=1.5.3
 opencv-python>=4.5.3.56
-torchmetrics>=0.7.0
+torchmetrics==0.7.0
 ruamel.yaml<=0.16.6
 matplotlib>=3.0.0
 importlib_metadata

--- a/tests/unittests/functional/test_pandas.py
+++ b/tests/unittests/functional/test_pandas.py
@@ -1,0 +1,63 @@
+# Copyright 2021 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+import towhee
+# pylint: disable=import-outside-toplevel
+
+
+class TestEntity(unittest.TestCase):
+    """
+    Unit test for Pandas related functions.
+    """
+
+    def test_from_pd(self):
+        import pandas as pd
+
+        df = pd.DataFrame(dict(a=range(5), b=range(5)))
+        dc = towhee.from_df(df)
+        self.assertListEqual(dc.df.a.to_list(), [0, 1, 2, 3, 4])
+
+        dc.df.b = [0, 2, 4, 6, 8]
+        self.assertListEqual(dc.df['b'].to_list(), [0, 2, 4, 6, 8])
+        self.assertEqual(repr(dc),
+                         '   a  b\n0  0  0\n1  1  2\n2  2  4\n3  3  6\n4  4  8')
+
+    def test_dataframe_map_siso(self):
+        import pandas as pd
+
+        df = pd.DataFrame(dict(a=range(5), b=range(5)))
+        dc = towhee.from_df(df)
+        dc = dc.runas_op['a', 'c'](func=lambda x: x + 1)
+        self.assertListEqual(dc['c'].to_list(), [1, 2, 3, 4, 5])
+
+    def test_dataframe_map_miso(self):
+        import pandas as pd
+
+        df = pd.DataFrame(dict(a=range(5), b=range(5)))
+        dc = towhee.from_df(df)
+        dc = dc.runas_op[('a', 'b'), 'c'](func=lambda x, y: x + y)
+        self.assertListEqual(dc['c'].to_list(), [0, 2, 4, 6, 8])
+
+    def test_dataframe_map_mimo(self):
+        import pandas as pd
+
+        df = pd.DataFrame(dict(a=range(5), b=range(5)))
+        dc = towhee.from_df(df)
+        dc = dc.runas_op[('a', 'b'), ('c', 'd')](func=lambda x, y: (x + y, x - y))
+        self.assertListEqual(dc['c'].to_list(), [0, 2, 4, 6, 8])
+        self.assertListEqual(dc['d'].to_list(), [0, 0, 0, 0, 0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/towhee/functional/__init__.py
+++ b/towhee/functional/__init__.py
@@ -100,9 +100,11 @@ read_camera = DataCollection.from_camera
 from_zip = DataCollection.from_zip
 
 
-def from_df(df):
-    return DataCollection.stream(
-        df.iterrows()).map(lambda x: Entity(**x[1].to_dict()))
+def from_df(df, as_stream=False):
+    if as_stream:
+        return DataCollection.stream(
+            df.iterrows()).map(lambda x: Entity(**x[1].to_dict()))
+    return DataCollection(df)
 
 
 def _glob_call_back(_, index, *arg, **kws):

--- a/towhee/functional/mixins/dataset.py
+++ b/towhee/functional/mixins/dataset.py
@@ -144,7 +144,7 @@ class DatasetMixin:
         from towhee.utils import sklearn_utils
         train_size = size[0]
         test_size = size[1]
-        train, test = sklearn_utils.train_test_split(list(self), train_size=train_size, test_size=test_size, **kws)
+        train, test = sklearn_utils.train_test_split(self._iterable, train_size=train_size, test_size=test_size, **kws)
         return self._factory(train), self._factory(test)
 
     def save_json(self):

--- a/towhee/functional/mixins/entity_mixin.py
+++ b/towhee/functional/mixins/entity_mixin.py
@@ -15,6 +15,7 @@ from typing import Dict, Any, Optional, Set, Union, List
 
 from towhee.functional.entity import Entity
 from towhee.hparam import param_scope
+# pylint: disable=import-outside-toplevel
 
 
 def _select_callback(self):
@@ -252,6 +253,14 @@ class EntityMixin:
             return x
 
         return self._factory(map(inner, self._iterable))
+
+    @property
+    def df(self):
+        import pandas as pd
+        if isinstance(self._iterable, pd.DataFrame):
+            return self._iterable
+        else:
+            raise TypeError('data collection is not created from pandas DataFrame.')
 
 
 if __name__ == '__main__':

--- a/towhee/functional/mixins/state.py
+++ b/towhee/functional/mixins/state.py
@@ -104,10 +104,13 @@ class StateMixin:
             op.set_training(True)
             with param_scope() as hp:
                 hp().towhee.data_collection.training = True
-                for x in self._iterable:
+                for x in self:
                     op(x)
             op.set_training(False)
             op.fit()
+        if hasattr(self._iterable, 'apply') and hasattr(op, '__dataframe_apply__'):
+            return self._factory(op.__dataframe_apply__(self._iterable))
+
         return self._factory(map(op, self._iterable))
 
 


### PR DESCRIPTION
Signed-off-by: jie.hou <jie.hou@zilliz.com>

support to create data collection from pandas, and use `DataFrame.apply` for computation, which is suppose to be faster for numerical columns.

For example, we first create a DataFrame with pandas:

```python
import pandas as pd
df = pd.DataFrame(dict(a=range(3),b=range(3)))
```

The result DataFrame:

```
   a  b
0  0  0
1  1  1
2  2  2
```

We are able to apply operators to the DataFrame with `DataCollection`

```python
dc = towhee.from_df(df) \
    .runas_op[('a', 'b'), 'c'](func=lambda x, y: x + y)
```

```
   a  b  c
0  0  0  0
1  1  1  2
2  2  2  4
```