### PR TITLE
Optimize APIs to call timesformer & vit from towhee.models

### DIFF
--- a/tests/unittests/models/timesformer/test_timesformer.py
+++ b/tests/unittests/models/timesformer/test_timesformer.py
@@ -14,7 +14,7 @@
 
 import unittest
 import torch
-from towhee.models.timesformer.timesformer import TimeSformer, timesformer
+from towhee.models import timesformer
 
 
 class TestTimesformer(unittest.TestCase):
@@ -26,15 +26,21 @@ class TestTimesformer(unittest.TestCase):
 
     # timesformer_k400_8x32 with attention_type='divided_space_time',
     def test_timesformer(self, video=dummy_video):
-        model = timesformer(model_name='timesformer_k400_8x224', pretrained=False)
+        model = timesformer.create_model(model_name='timesformer_k400_8x224', pretrained=False)
         pred = model(video)
+        feats = model.forward_features(video)
         self.assertTrue(pred.shape == (1, 400))
+        self.assertTrue(feats.shape == (1, 768))
 
     def test_other_types(self, video=dummy_video):
         for attention_type in ['space_only', 'joint_space_time']:
-            model = TimeSformer(img_size=224, num_classes=400, num_frames=4, attention_type=attention_type)
+            model = timesformer.create_model(
+                pretrained=False,
+                img_size=224, num_classes=400, num_frames=4, attention_type=attention_type)
             pred = model(video)
+            feats = model.forward_features(video)
             self.assertTrue(pred.shape == (1, 400))
+            self.assertTrue(feats.shape == (1, 768))
 
 
 if __name__ == '__main__':

--- a/tests/unittests/models/vit/test_vit.py
+++ b/tests/unittests/models/vit/test_vit.py
@@ -19,13 +19,13 @@ from PIL import Image
 import torch
 from torchvision import transforms
 
-from towhee.models.vit import vit
+from towhee.models import vit
 from tests.unittests import VIT_DIR
 
 
 class VisionTransformerTest(unittest.TestCase):
     test_dir = VIT_DIR
-    model = vit(model_name='vit_base_16x224')
+    model = vit.create_model(model_name='vit_base_16x224', pretrained=True)
     img = Image.open(os.path.join(test_dir, 'img.jpg'))
     tfms = transforms.Compose([transforms.Resize(256),
                                transforms.CenterCrop(224),
@@ -50,6 +50,14 @@ class VisionTransformerTest(unittest.TestCase):
             p = prob * 100
             print(f'[{idx}] {label:<75} ({p:.2f}%)')
             self.assertEqual('giant panda, panda, panda bear, coon bear, Ailuropoda melanoleuca', self.labels_map[idx])
+
+    def test_model(self):
+        dummy_img = torch.rand(1, 3, 224, 224)
+        model = vit.create_model(num_classes=400)
+        features = model.forward_features(dummy_img)
+        self.assertTrue(features.shape, (1, 768))
+        out = model(dummy_img)
+        self.assertTrue(out.shape, (1, 400))
 
 
 if __name__ == '__main__':

--- a/towhee/models/timesformer/__init__.py
+++ b/towhee/models/timesformer/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .timesformer import timesformer
+from .timesformer import *

--- a/towhee/models/timesformer/timesformer_utils.py
+++ b/towhee/models/timesformer/timesformer_utils.py
@@ -59,9 +59,7 @@ def load_pretrained(
         cfg,
         checkpoint_path=None,
         strict=True,
-        device='cpu'
-):
-
+        device='cpu'):
     num_classes = cfg['num_classes']
     in_c = cfg['in_c']
     img_size = cfg['img_size']
@@ -172,7 +170,7 @@ def load_pretrained(
     return model
 
 
-def get_configs(model_name):
+def get_configs(model_name: str = None):
     if model_name == 'timesformer_k400_8x224':
         configs = vit_configs('vit_base_16x224')
         configs.update(dict(
@@ -186,4 +184,4 @@ def get_configs(model_name):
             classifier='head',
             filter_fn=None,
         ))
-        return configs
+    return configs

--- a/towhee/models/vit/__init__.py
+++ b/towhee/models/vit/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .vit import vit
+from .vit import *

--- a/towhee/models/vit/vit.py
+++ b/towhee/models/vit/vit.py
@@ -120,30 +120,36 @@ class VitModel(nn.Module):
         return x
 
 
-def vit(
-        model_name: str = "vit_base_16x224",
-        pretrained: bool = True,
+def create_model(
+        model_name: str = None,
+        pretrained: bool = False,
         weights_path: str = None,
-        device: str = None
+        device: str = None,
+        **kwargs
         ):
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
 
-    configs = get_configs(model_name)
-    if "url" in configs:
-        url = configs["url"]
-        configs.pop("url")
+    if model_name is None:
+        if pretrained:
+            raise AssertionError("Fail to load pretrained model: no model name is specified.")
+        model = VitModel(**kwargs)
+    else:
+        configs = get_configs(model_name)
+        if "url" in configs:
+            url = configs["url"]
+            configs.pop("url")
 
-    model = VitModel(**configs)
+        model = VitModel(**configs)
 
-    if pretrained:
-        if weights_path:
-            state_dict = torch.load(weights_path)
-        elif url:
-            state_dict = model_zoo.load_url(url, map_location=torch.device(device))
-        else:
-            raise AssertionError("No model weights url or path is provided.")
-        model.load_state_dict(state_dict, strict=False)
+        if pretrained:
+            if weights_path:
+                state_dict = torch.load(weights_path)
+            elif url:
+                state_dict = model_zoo.load_url(url, map_location=torch.device(device))
+            else:
+                raise AssertionError("No model weights url or path is provided.")
+            model.load_state_dict(state_dict, strict=False)
 
     model.eval()
     return model

--- a/towhee/trainer/utils/layer_freezer.py
+++ b/towhee/trainer/utils/layer_freezer.py
@@ -13,8 +13,8 @@ class LayerFreezer:
 
     Example:
         >>> from towhee.trainer.utils.layer_freezer import LayerFreezer
-        >>> from towhee.models.vit.vit import VitModel
-        >>> my_model = VitModel('vit_base_patch16_224')
+        >>> from towhee.models import vit
+        >>> my_model = vit.create_model()
         >>> my_freezer = LayerFreezer(my_model)
         >>> # Check if modules in the last layer are frozen
         >>> my_freezer.status(-1)


### PR DESCRIPTION
Signed-off-by: Jael Gu <mengjia.gu@zilliz.com>

Example usage:
```
from towhee.models import vit
from towhee.models import timesformer

model = vit.create_model()
model = timesformer.create_model()
```