### PR TITLE
feat: auto install  when module not found

### DIFF
--- a/towhee/utils/pandas_utils.py
+++ b/towhee/utils/pandas_utils.py
@@ -13,10 +13,19 @@
 # limitations under the License.
 
 from towhee.utils.log import engine_log
+import os
 
 try:
     # pylint: disable=unused-import
     import pandas
-except ModuleNotFoundError as e:
-    engine_log.error('pandas not found, you can install via `pip install pandas`.')
-    raise ModuleNotFoundError('pandas not found, you can install via `pip install pandas`.') from e
+except ModuleNotFoundError as moduleNotFound:
+    engine_log.error('pandas not found, try to install pandas automatically.')
+
+    try:
+        # try to install automatically, and reload the `pandas` module
+        os.system("pip install pandas")
+        # pylint: disable=unused-import
+        import pandas
+    except:
+        engine_log.error('pandas not found, you can install via `pip install pandas`.')
+        raise ModuleNotFoundError('pandas not found, you can install via `pip install pandas`.') from moduleNotFound

--- a/towhee/utils/pandas_utils.py
+++ b/towhee/utils/pandas_utils.py
@@ -23,7 +23,7 @@ except ModuleNotFoundError as moduleNotFound:
 
     try:
         # try to install automatically, and reload the `pandas` module
-        os.system("pip install pandas")
+        os.system('pip install pandas')
         # pylint: disable=unused-import
         import pandas
     except:


### PR DESCRIPTION
Hello maintainers 👋

I'm using towhee to complete a quick use of a some model project. During the process, I encountered a problem similar to the following:

```bash
2022-05-19 10:44:32,921 - 140310832697728 - pandas_utils.py-pandas_utils:23 - ERROR: pandas not found, you can install via `pip install pandas`.
```

Why prompt the user to manually install pandas when towhee has made the code incredibly simple? So, I submitted a simple modification, hoping to help the project.
