### PR TITLE
Remove dtype scale from video_transforms

### DIFF
--- a/towhee/models/utils/video_transforms.py
+++ b/towhee/models/utils/video_transforms.py
@@ -22,7 +22,7 @@ import numpy
 import torch
 from torch import nn
 
-from torchvision.transforms import Compose, Lambda
+from torchvision.transforms import Compose
 
 try:
     from torchvideo.transforms import (
@@ -124,7 +124,6 @@ class VideoTransforms:
             raise KeyError from e
 
         tfms_list = [UniformTemporalSubsample(self.num_frames),
-                     Lambda(lambda x: x / 255.0),
                      NormalizeVideo(mean=self.mean, std=self.std, inplace=True),
                      ShortSideScale(size=self.side_size),
                      CenterCropVideo(size=(self.crop_size, self.crop_size)),


### PR DESCRIPTION
Signed-off-by: Jael Gu <mengjia.gu@zilliz.com>

- input data should be scaled together with change of dtype outside transforms
- completely remove x/255. from transforms