### PR TITLE
Fix issue when save image list

### DIFF
--- a/towhee/hub/builtin/operators/computer_vision.py
+++ b/towhee/hub/builtin/operators/computer_vision.py
@@ -234,14 +234,16 @@ class save_image:
     """
 
     def __init__(self, dir: str):
-        self._file = str(uuid.uuid4()) + '.jpg'
-        self._img_path = str(Path(dir) / self._file)
-        if not Path(dir).exists():
-            Path(dir).mkdir(parents=True)
+        self._dir = dir
+        if not Path(self._dir).exists():
+            Path(self._dir).mkdir(parents=True)
 
     def __call__(self, img):
         from towhee.utils.pil_utils import PILImage
         from towhee.utils.ndarray_utils import cv2
+
+        self._file = str(uuid.uuid4()) + '.jpg'
+        self._img_path = str(Path(self._dir) / self._file)
         if isinstance(img, PILImage.Image):
             img.save(self._img_path)
         elif isinstance(img, (Image, np.ndarray)):


### PR DESCRIPTION
Signed-off-by: shiyu22 <shiyu.chen@zilliz.com>

When I run the following code, the previous code will only save one image.
```python
import towhee
towhee.glob('test1.png', 'test2.png') \
      .image_decode() \
      .img2img_translation.cartoongan(model_name = 'Hayao') \
      .save_image(dir='data/tmp') \
      .to_list()
```