### PR TITLE
fix #1275

### DIFF
--- a/towhee/doc/source/data_collection/get_started.rst
+++ b/towhee/doc/source/data_collection/get_started.rst
@@ -2,5 +2,5 @@
 Get Started
 ===========
 
-.. include:: ../../../../docs/get-started/data-collection.md
+.. include:: ../../../../docs/03-User Guides/02-DataCollection/01-data-collection.md
    :parser: myst_parser.sphinx_

--- a/towhee/doc/source/towhee/towhee.rst
+++ b/towhee/doc/source/towhee/towhee.rst
@@ -1,6 +1,8 @@
 towhee 
 ------
 
+.. autodata:: towhee.api
+
 .. autodata:: towhee.dc
 
 .. autodata:: towhee.ops


### PR DESCRIPTION
Signed-off-by: jie.hou <jie.hou@zilliz.com>

doctest finder does not support global variables, we can't directly apply the decorator to the function if we want both sphinx docs and doctest.