### PR TITLE
Add  supported_model_names to NNOperator

### DIFF
--- a/tests/unittests/operators/test_operator_base.py
+++ b/tests/unittests/operators/test_operator_base.py
@@ -46,6 +46,11 @@ class TestOperator(unittest.TestCase):
         except NotImplementedError:
             pass
 
+        try:
+            pt_op.supported_model_names()
+        except NotImplementedError:
+            pass
+
         pt_op.framework = 'tensorflow'
         self.assertEqual(pt_op.framework, tf_op.framework)
 

--- a/towhee/operator/base.py
+++ b/towhee/operator/base.py
@@ -120,6 +120,15 @@ class NNOperator(Operator):
         self._framework = framework
 
     def save_model(self):
+        """
+        Save model to local.
+        """
+        raise NotImplementedError
+
+    def supported_model_names(self):
+        """
+        Return a list of supported model names.
+        """
         raise NotImplementedError
 
     def train(self,


### PR DESCRIPTION
Signed-off-by: Jael Gu <mengjia.gu@zilliz.com>

/Close #1333 

Example refer to https://towhee.io/text-embedding/transformers/src/branch/main/auto_transformers.py.
Example usage:
```
from auto_transformers import AutoTransformers

supported_models = AutoTransformers.supported_model_names()
pytorch_models = AutoTransformers.supported_model_names(format='pytorch')
torchscript_models = AutoTransformers.supported_model_names(format='torchscript')
```