### PR TITLE
Adjust the file name to be consistent with the project code style

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <h3 align="center">
   <p style="text-align: center;">
-  <a href="https://github.com/towhee-io/towhee/blob/main/README.md" target="_blank">ENGLISH</a> | <a href="https://github.com/towhee-io/towhee/blob/main/README-CN.md">中文文档</a>
+  <a href="https://github.com/towhee-io/towhee/blob/main/README.md" target="_blank">ENGLISH</a> | <a href="https://github.com/towhee-io/towhee/blob/main/README_CN.md">中文文档</a>
   </p>
 </h3>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -12,7 +12,7 @@
 
 <h3 align="center">
   <p style="text-align: center;">
-  <a href="https://github.com/towhee-io/towhee/blob/main/README.md" target="_blank">ENGLISH</a> | <a href="https://github.com/towhee-io/towhee/blob/main/README-CN.md">中文文档</a>
+  <a href="https://github.com/towhee-io/towhee/blob/main/README.md" target="_blank">ENGLISH</a> | <a href="https://github.com/towhee-io/towhee/blob/main/README_CN.md">中文文档</a>
   </p>
 </h3>
 


### PR DESCRIPTION
I found a problem in the previous PR, the naming of the Chinese document is not consistent with the project code style.

In this commit, I fixed the issue, replacing hyphens with underscores.