### PR TITLE
Allow users to selectively use MIRROR when building docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,16 @@ ARG PYTHON_VERSION=3.8
 # base image, build command: 
 # docker build --platform x86_64 --target towhee-base  -t towhee/towhee-base:latest .
 FROM ${BASE_IMAGE} as towhee-base
-RUN sed -i "s@http://.*archive.ubuntu.com@http://mirrors.tuna.tsinghua.edu.cn@g" /etc/apt/sources.list
-RUN sed -i "s@http://.*security.ubuntu.com@http://mirrors.tuna.tsinghua.edu.cn@g" /etc/apt/sources.list
+
+# Speed ​​up for Chinese users, only if user specified `USE_MIRROR=true`
+# In addition, use the default software source of the base image and language
+ARG USE_MIRROR=false
+ENV USE_MIRROR=${USE_MIRROR}
+RUN if [ "$USE_MIRROR" = "true" ]; then sed -i -e "s/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/" /etc/apt/sources.list && sed -i -e "s/security.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/" /etc/apt/sources.list; fi
+
 RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
-    apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        git && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git && \
+    apt autoremove && apt clean
 ENV PATH /opt/conda/bin:$PATH
 
 # conda image, build command: 
@@ -22,7 +24,7 @@ ARG CUDA_VERSION=11.3
 ARG CUDA_CHANNEL=nvidia
 ARG INSTALL_CHANNEL=pytorch
 COPY requirements.txt .
-RUN curl -fsSL -v -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+RUN curl -fsSL -v -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     chmod +x ~/miniconda.sh && \
     ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ FROM ${BASE_IMAGE} as towhee-base
 # In addition, use the default software source of the base image and language
 ARG USE_MIRROR=false
 ENV USE_MIRROR=${USE_MIRROR}
-RUN if [ "$USE_MIRROR" = "true" ]; then sed -i -e "s/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/" /etc/apt/sources.list && sed -i -e "s/security.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/" /etc/apt/sources.list; fi
+ARG UBUNTU_MIRROR="mirrors.tuna.tsinghua.edu.cn"
+ENV UBUNTU_MIRROR=${UBUNTU_MIRROR}
+RUN if [ "$USE_MIRROR" = "true" ]; then sed -i -e "s/archive.ubuntu.com/${UBUNTU_MIRROR}/" /etc/apt/sources.list && sed -i -e "s/security.ubuntu.com/${UBUNTU_MIRROR}/" /etc/apt/sources.list; fi
 
 RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
     apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git && \


### PR DESCRIPTION
When the current user builds the Towhee image, they is forced to use the university software source in China.

Maybe it makes more sense to make this optional.