### PR TITLE
Improve the MIRROR function in the Towhee Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,16 @@ RUN if [ "$USE_MIRROR" = "true" ]; then export CONDA_SRC="${CONDA_MIRROR}/minico
     chmod +x ~/miniconda.sh && \
     ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \
-    /opt/conda/bin/conda install -y python=${PYTHON_VERSION} cmake conda-build pyyaml numpy ipython
+    if [ "$USE_MIRROR" = "true" ]; then \
+        echo "channels:" > $HOME/.condarc && \
+        echo "  - ${CONDA_SRC}/pkgs/free/" >> $HOME/.condarc && \
+        echo "  - ${CONDA_SRC}/pkgs/main/" >> $HOME/.condarc && \
+        echo "  - ${CONDA_SRC}/cloud/pytorch/" >> $HOME/.condarc && \
+        echo "  - defaults" >> $HOME/.condarc && \
+        echo "show_channel_urls: true" >> $HOME/.condarc; \
+    fi
+
+RUN /opt/conda/bin/conda install -y python=${PYTHON_VERSION} cmake conda-build pyyaml numpy ipython
 ENV CONDA_OVERRIDE_CUDA=${CUDA_VERSION}
 RUN /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -c "${CUDA_CHANNEL}" -y python=${PYTHON_VERSION} pytorch torchvision torchaudio torchtext "cudatoolkit=${CUDA_VERSION}" && \
     /opt/conda/bin/conda clean -ya

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,9 @@ RUN if [ "$USE_MIRROR" = "true" ]; then export CONDA_SRC="${CONDA_MIRROR}/minico
     rm ~/miniconda.sh && \
     if [ "$USE_MIRROR" = "true" ]; then \
         echo "channels:" > $HOME/.condarc && \
-        echo "  - ${CONDA_SRC}/pkgs/free/" >> $HOME/.condarc && \
-        echo "  - ${CONDA_SRC}/pkgs/main/" >> $HOME/.condarc && \
-        echo "  - ${CONDA_SRC}/cloud/pytorch/" >> $HOME/.condarc && \
+        echo "  - ${CONDA_MIRROR}/pkgs/free/" >> $HOME/.condarc && \
+        echo "  - ${CONDA_MIRROR}/pkgs/main/" >> $HOME/.condarc && \
+        echo "  - ${CONDA_MIRROR}/cloud/pytorch/" >> $HOME/.condarc && \
         echo "  - defaults" >> $HOME/.condarc && \
         echo "show_channel_urls: true" >> $HOME/.condarc; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,12 @@ ARG CUDA_VERSION=11.3
 ARG CUDA_CHANNEL=nvidia
 ARG INSTALL_CHANNEL=pytorch
 COPY requirements.txt .
-RUN curl -fsSL -v -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+
+ARG CONDA_MIRROR="https://mirrors.tuna.tsinghua.edu.cn/anaconda"
+ENV CONDA_MIRROR=${CONDA_MIRROR}
+ENV CONDA_SRC="https://repo.anaconda.com/miniconda"
+RUN if [ "$USE_MIRROR" = "true" ]; then export CONDA_SRC="${CONDA_MIRROR}/miniconda"; fi && \
+    curl -fsSL -v -o ~/miniconda.sh -O  "$CONDA_SRC/Miniconda3-latest-Linux-x86_64.sh" && \
     chmod +x ~/miniconda.sh && \
     ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \


### PR DESCRIPTION
Issue: https://github.com/towhee-io/towhee/issues/1738

Continue to improve the Mirror function in the Towhee project, so that those who need to use the Mirror function can complete the mirror construction faster.


In a previous commit, I added an option to optionally use MIRROR to build the Towhee Dockerfile.

The "MIRROR" behavior was inherited from the original project at the time, which could speed up the installation of Ubuntu software. In this PR, I added an option to speed up the installation of CONDA, and the installation of CONDA software.