### PR TITLE
Fixed static resources referenced by Towhee Model documentation page in GitHub dark mode

### DIFF
--- a/towhee/models/README.md
+++ b/towhee/models/README.md
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and limitations 
 -->
 
 ![https://towhee.io](../../towhee_logo.png#gh-light-mode-only)
-![https://towhee.io](../../towhee_logo_dark.png#gh-dark-mode-only)
+![https://towhee.io](../../assets/towhee_logo_dark.png#gh-dark-mode-only)
 
 <h3 align="center">
   <p style="text-align: center;"> <span style="font-weight: bold; font: Arial, sans-serif;">x</span>2vec, Towhee is all you need! </p>

--- a/towhee/models/README_CN.md
+++ b/towhee/models/README_CN.md
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and limitations 
 -->
 
 ![https://towhee.io](../../towhee_logo.png#gh-light-mode-only)
-![https://towhee.io](../../towhee_logo_dark.png#gh-dark-mode-only)
+![https://towhee.io](../../assets/towhee_logo_dark.png#gh-dark-mode-only)
 
 <h3 align="center">
   <p style="text-align: center;"> <span style="font-weight: bold; font: Arial, sans-serif;">x</span>2vec, Towhee is all you need! </p>


### PR DESCRIPTION
Similar to the changes in the previous PR, correct resource references in the Towhee Model documentation in GitHub dark mode.

Sorry, I left out these two documents, after reconfirmation, all resource references are correct @reiase 

Issue: https://github.com/towhee-io/towhee/issues/1768