### PR TITLE
Update 10-minutes-to-towhee.md

### DIFF
--- a/towhee/doc/source/user_guide/10-minutes-to-towhee.md
+++ b/towhee/doc/source/user_guide/10-minutes-to-towhee.md
@@ -8,7 +8,7 @@ This section is a short introduction to `Pipeline`, an unstructured data process
 The latest version of `towhee` can be installed with `pip`, or `python -m pip` if `pip` is not presented in your `PATH`:
 
 ```shell
-$ pip install towhee
+$ pip install towhee==1.0.0rc1
 ```
 
 
@@ -153,10 +153,10 @@ p = (
 	pipe.input('num', 'timestamp')
 		.flat_map(('num', 'timestamp'), ('num', 'timestamp'), lambda x,y: [(i, j) for i, j in zip(x, y)])
 		.time_window('num', 'nums', 'timestamp', 2, 1, lambda x: x)
-		.output('num', 'timestamp', 'nums')
+		.output('nums')
 )
 
-res = p([1, 2, 3, 4, 5], [0, 1000, 2000, 4000, 5000])
+res = p([0, 1, 2, 4, 5], [0, 1000, 2000, 4000, 5000])
 print(res.to_list())
 # [[[0, 1]], [[1, 2]], [[2]], [[4]], [[4, 5]], [[5]]]
 
@@ -270,7 +270,7 @@ ops.add_x(x=1)(2)
 
 ### Run Operator with `Pipeline`
 
-When an operator is uploaded to the Towhee hub or registered with @register, we can call the operato directly on a Pipeline:
+When an operator is uploaded to the Towhee hub or registered with @register, we can call the operator directly on a Pipeline:
 ```python
 from towhee import ops, pipe
 p = (

--- a/towhee/doc/source/user_guide/10-minutes-to-towhee.md
+++ b/towhee/doc/source/user_guide/10-minutes-to-towhee.md
@@ -8,7 +8,7 @@ This section is a short introduction to `Pipeline`, an unstructured data process
 The latest version of `towhee` can be installed with `pip`, or `python -m pip` if `pip` is not presented in your `PATH`:
 
 ```shell
-$ pip install towhee==1.0.0rc1
+$ pip install towhee
 ```
 
 


### PR DESCRIPTION
1. Fix the typo in `Time Window` example. (ref. https://github.com/towhee-io/towhee/issues/2542
2. Fix typo: change `operato` to `operator`.
3. ~~Specify version in the pip install. Pip default install 0.9.0 towhee which is inconsistent with examples in the document. Specify 1.0 version of towhee.~~