### PR TITLE
window报错: argument of type 'WindowsPath' is not iterable

### DIFF
--- a/towhee/hub/downloader.py
+++ b/towhee/hub/downloader.py
@@ -175,7 +175,7 @@ def download_operator(author: str, repo: str, tag: str, op_path: Path, install_r
     fs.symlink_files(latest)
 
     if install_reqs and fs.requirements:
-        subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-r', fs.requirements])
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-r', str(fs.requirements)])
 
 
 def download_pipeline(author: str, repo: str, tag: str, pipe_path: Path, latest: bool = False):


### PR DESCRIPTION
.towhee不存在时，加载文件，加载文件后会 install requirements.txt ，此处window会报错